### PR TITLE
Further tidying to merge TMA tracks

### DIFF
--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/MergeTracks.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/MergeTracks.java
@@ -171,9 +171,9 @@ public class MergeTracks implements RightClickContextItemGenerator
 		private final Layers _layers;
 		private final Layer[] _parents;
 		private final Editable[] _subjects;
-		private final Editable _target;
+		private final TrackWrapper _target;
 
-		public MergeTracksOperation(final String title, final Editable target,
+		public MergeTracksOperation(final String title, final TrackWrapper target,
 				final Layers theLayers, final Layer[] parentLayers, final Editable[] subjects)
 		{
 			super(title);

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/TrackWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/TrackWrapper.java
@@ -312,7 +312,7 @@ public class TrackWrapper extends MWC.GUI.PlainWrapper implements
 	 *          name to give to the merged object
 	 * @return sufficient information to undo the merge
 	 */
-	public static int mergeTracks(final Editable recipient,
+	public static int mergeTracks(final TrackWrapper recipient,
 			final Layers theLayers, final Editable[] subjects)
 	{
 		// where we dump the new data points

--- a/org.mwc.debrief.satc.integration/src/org/mwc/debrief/satc_interface/data/SATC_Solution.java
+++ b/org.mwc.debrief.satc.integration/src/org/mwc/debrief/satc_interface/data/SATC_Solution.java
@@ -583,9 +583,12 @@ public class SATC_Solution extends BaseLayer implements
 						DebriefPlugin.logError(IStatus.ERROR,
 								"Unexpected type of route encountered:" + thisLeg, null);
 				}
-
+				
 				// and store it
 				_myLayers.addThisLayer(newT);
+				
+				// and hide ourselves
+				setVisible(false);
 
 			}
 		}
@@ -638,6 +641,9 @@ public class SATC_Solution extends BaseLayer implements
 
 				// and store it
 				_myLayers.addThisLayer(newT);
+				
+				// and hide ourselves
+				setVisible(false);
 			}
 		}
 	}


### PR DESCRIPTION
(Associated with ticket #589 )
- hide TMA solution after converting to legs/standalone track
- tighter Class checking on merge operation
