### PR TITLE
Issue #672 - 'Download Debrief' should be an explicit folder

### DIFF
--- a/org.mwc.cmap.core/pom.xml
+++ b/org.mwc.cmap.core/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.mwc.debrief</groupId>
   <artifactId>org.mwc.cmap.core</artifactId>
-  <version>1.0.173</version>
+  <version>1.0.174</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.mwc.debrief.TimeBar/pom.xml
+++ b/org.mwc.debrief.TimeBar/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.mwc.debrief</groupId>
   <artifactId>org.mwc.debrief.TimeBar</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.mwc.debrief.core/pom.xml
+++ b/org.mwc.debrief.core/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.mwc.debrief</groupId>
   <artifactId>org.mwc.debrief.core</artifactId>
-  <version>1.0.221</version>
+  <version>1.0.223</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.mwc.debrief.help/pom.xml
+++ b/org.mwc.debrief.help/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.mwc.debrief</groupId>
   <artifactId>org.mwc.debrief.help</artifactId>
-  <version>1.0.114</version>
+  <version>1.0.115</version>
   <packaging>eclipse-plugin</packaging>
   <build>
     <plugins>

--- a/org.mwc.debrief.product/pom.xml
+++ b/org.mwc.debrief.product/pom.xml
@@ -34,6 +34,12 @@
 						<linux>tar.gz</linux>
 						<macosx>tar.gz</macosx>
 					</formats>
+					<products>
+      						<product>
+							<id>DebriefNG</id>
+							<rootFolder>DebriefNG</rootFolder>`
+      						</product>
+    					</products>
 				</configuration>
 				<executions>
 					<execution>
@@ -50,6 +56,35 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+        			<groupId>org.apache.maven.plugins</groupId>
+        			<artifactId>maven-antrun-plugin</artifactId>
+        			<version>1.7</version>
+				<executions>
+          				<execution>
+            					<phase>verify</phase>
+            					<configuration>
+              						<tasks>
+DebriefNG-macosx.cocoa.x86_64.tar.gz  DebriefNG-win32.win32.x86.zip
+DebriefNG-linux.gtk.x86_64.tar.gz  DebriefNG-win32.win32.x86_64.zip      DebriefNG-Windows32Bit.tar.gz
+								<rename src="${project.build.directory}/products/DebriefNG-linux.gtk.x86.tar.gz"
+									dest="${project.build.directory}/products/DebriefNG-Linux32Bit.tar.gz"/>
+								<rename src="${project.build.directory}/products/DebriefNG-linux.gtk.x86_64.tar.gz"
+									dest="${project.build.directory}/products/DebriefNG-Linux64Bit.tar.gz"/>
+								<rename src="${project.build.directory}/products/DebriefNG-win32.win32.x86.zip"
+									dest="${project.build.directory}/products/DebriefNG-Windows32Bit.zip"/>
+								<rename src="${project.build.directory}/products/DebriefNG-win32.win32.x86_64.zip"
+									dest="${project.build.directory}/products/DebriefNG-Windows64Bit.zip"/>
+								<rename src="${project.build.directory}/products/DebriefNG-macosx.cocoa.x86_64.tar.gz"
+									dest="${project.build.directory}/products/DebriefNG-MacOSX64Bit.tar.gz"/>
+              						</tasks>
+            					</configuration>
+            						<goals>
+              							<goal>run</goal>
+            						</goals>
+          				</execution>
+        			</executions>
+      			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/org.mwc.debrief.satc.core/pom.xml
+++ b/org.mwc.debrief.satc.core/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.mwc.debrief</groupId>
   <artifactId>org.mwc.debrief.satc.core</artifactId>
-  <version>1.0.8</version>
+  <version>1.0.9</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.mwc.debrief.track_shift/pom.xml
+++ b/org.mwc.debrief.track_shift/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.mwc.debrief</groupId>
   <artifactId>org.mwc.debrief.track_shift</artifactId>
-  <version>1.0.53</version>
+  <version>1.0.55</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     <module>org.mwc.cmap.core</module>
     <module>org.mwc.cmap.grideditor</module>
     <module>org.mwc.cmap.gt2Plot</module>
-<!--    <module>org.mwc.cmap.installer</module> -->
-    <module>org.mwc.cmap.layer_manager</module>
+<!--    <module>org.mwc.cmap.installer</module>
+    <module>org.mwc.cmap.layer_manager</module> -->
     <module>org.mwc.cmap.legacy</module>
     <module>org.mwc.cmap.overview</module>
     <module>org.mwc.cmap.plotViewer</module>


### PR DESCRIPTION
I have added the following features:
- fix the version for a few plugins in order to build works

Notice:
When you update some plugin, you would also update corresponding version in pom.xml as well as version in feature.xml/pom.xml in plugin's feature (org.mwc.cmap.combined.feature or org.mwc.debrief.combined.feature)
- change final product names to:

DebriefNG-Linux32Bit.tar.gz
DebriefNG-Linux64Bit.tar.gz
DebriefNG-MacOSX64Bit.tar.gz
DebriefNG-Windows32Bit.zip
DebriefNG-Windows64Bit.zip
- root folder for all archives is DebriefNG
