### PR TITLE
don't include GND manager in build any more.

### DIFF
--- a/org.mwc.debrief.combined.feature/feature.xml
+++ b/org.mwc.debrief.combined.feature/feature.xml
@@ -234,13 +234,6 @@ Library.
          unpack="false"/>
 
    <plugin
-         id="org.mwc.debrief.GNDManager"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.mwc.debrief.TimeBar"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
FIRST STEP of changes to remove GND from build (but keep it in repo)