### PR TITLE
Missing cuts in Residuals view #1065

### DIFF
--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java
@@ -161,7 +161,19 @@ public final class Doublet implements Comparable<Doublet>
 	public int compareTo(final Doublet o)
 	{
 		int res = 0;
-		res = _hostFix.getDTG().compareTo(o._hostFix.getDTG());
+		
+		// hmm, do they have the same host DTG?
+		if(_hostFix.getDTG().equals(o._hostFix.getDTG()))
+		{
+			// yes, then lets compare the target fixes. This happens
+			// when the sensor cuts are more frequent than the 
+			// sensor platform positions
+			res = _targetFix.getDTG().compareTo(o._targetFix.getDTG());					
+		}
+		else
+		{		
+			res = _hostFix.getDTG().compareTo(o._hostFix.getDTG());
+		}
 		return res;
 	}
 


### PR DESCRIPTION
We have a problem where some cuts are missing from the Bearing Residuals view, particularly when the sensor cuts are more frequent than the ownship cuts.

Fixes #1065 