### PR TITLE
Hotfix shape line widths

### DIFF
--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/CircleShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/CircleShape.java
@@ -217,7 +217,7 @@ public class CircleShape extends PlainShape implements Editable,
 	public CircleShape(final WorldLocation theCentre,
 			final WorldDistance theRadius)
 	{
-		super(0, 1, "Circle");
+		super(0, "Circle");
 
 		// store the values
 		_theCentre = theCentre;

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/EllipseShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/EllipseShape.java
@@ -220,7 +220,7 @@ public class EllipseShape extends PlainShape implements Editable
                       final WorldDistance theMaxima,
                       final WorldDistance theMinima)
   {
-    super(0, 1, "Ellipse");
+    super(0, "Ellipse");
 
     // store the values
     _theCentre = theCentre;

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/FurthestOnCircleShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/FurthestOnCircleShape.java
@@ -192,7 +192,7 @@ public class FurthestOnCircleShape extends PlainShape implements Editable
 	public FurthestOnCircleShape(final WorldLocation theCentre, final int numRings,
 			final WorldSpeed speed, final int interval, final int arcCentre, final int arcWidth)
 	{
-		super(0, 1, "Range Ring");
+		super(0, "Range Ring");
 
 		// store the values
 		_theCentre = theCentre;

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/LineShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/LineShape.java
@@ -187,7 +187,7 @@ public class LineShape extends PlainShape implements Editable,
 
 	public LineShape(final WorldLocation start, final WorldLocation end, final String name)
 	{
-		super(0, 1, name);
+		super(0, name);
 		// store the data
 		_start = start;
 		_end = end;

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/PlainShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/PlainShape.java
@@ -147,6 +147,8 @@ import MWC.GenericData.WorldLocation;
 abstract public class PlainShape implements Serializable, DraggableItem
 {
 
+	private static final int STANDARD_LINE_WIDTH = 2;
+
 	// ////////////////////////////////////////////////
 	// member variables
 	// ////////////////////////////////////////////////
@@ -229,12 +231,12 @@ abstract public class PlainShape implements Serializable, DraggableItem
 	 * @param theLineWidth
 	 * @param myType
 	 */
-	protected PlainShape(final int theLineStyle, final int theLineWidth, final String myType)
+	protected PlainShape(final int theLineStyle, final String myType)
 	{
 		_lineStyle = theLineStyle;
 		_foreColor = DEFAULT_COLOR; // set the colour to the default one for our
 																// colour editor
-		_lineWidth = theLineWidth;
+		_lineWidth = STANDARD_LINE_WIDTH;
 
 		final StringBuffer sb = new StringBuffer();
 		sb.append("Shape");

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/PolygonShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/PolygonShape.java
@@ -239,7 +239,7 @@ public class PolygonShape extends PlainShape implements Editable,
 	 */
 	public PolygonShape(final Vector<PolygonNode> vector)
 	{
-		super(0, 1, "Polygon");
+		super(0, "Polygon");
 
 		// and store it
 		_nodes = vector;

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/RangeRingShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/RangeRingShape.java
@@ -242,7 +242,7 @@ public class RangeRingShape extends PlainShape implements Editable
 	public RangeRingShape(final WorldLocation theCentre, final int numRings,
 			final WorldDistance ringWidth)
 	{
-		super(0, 1, "Range Ring");
+		super(0, "Range Ring");
 
 		// store the values
 		_theCentre = theCentre;

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/RectangleShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/RectangleShape.java
@@ -195,7 +195,7 @@ public class RectangleShape extends PlainShape implements Editable,
 	// ////////////////////////////////////////////////
 	public RectangleShape(final WorldLocation TL, final WorldLocation BR)
 	{
-		super(0, 1, "Rectangle");
+		super(0, "Rectangle");
 
 		_myArea = new WorldArea(TL, BR);
 		_myArea.normalise();

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/TextLabel.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/TextLabel.java
@@ -257,7 +257,7 @@ public class TextLabel extends PlainShape implements Editable
 	 */
 	public TextLabel(final WorldLocation theLocation, final String theString)
 	{
-		super(0, 1, "Text");
+		super(0, "Text");
 
 		_theString = theString;
 		_theLocation = theLocation;
@@ -272,7 +272,7 @@ public class TextLabel extends PlainShape implements Editable
 	 */
 	public TextLabel(final PlainShape theShape, final String theString)
 	{
-		super(0, 1, "Text");
+		super(0, "Text");
 
 		_theString =  replaceNewLines(theString);
 		_theShape = theShape;

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/WheelShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/WheelShape.java
@@ -265,7 +265,7 @@ public class WheelShape extends PlainShape implements Editable
 	public WheelShape(final WorldLocation theCentre, final WorldDistance theInnerRadius,
 			final WorldDistance theOuterRadius)
 	{
-		super(0, 1, "Wheel");
+		super(0, "Wheel");
 
 		// store the values
 		_theCentre = theCentre;

--- a/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/SnailPainter.java
+++ b/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/SnailPainter.java
@@ -901,7 +901,7 @@ public class SnailPainter extends TotePainter
 						if (dest instanceof Graphics2D)
 						{
 							final Graphics2D g2 = (Graphics2D) dest;
-							g2.setStroke(new BasicStroke(sw.getLineThickness()));
+							g2.setStroke(new BasicStroke(sw.getShape().getLineWidth()));
 						}
 					}
 

--- a/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportReplay.java
+++ b/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportReplay.java
@@ -961,11 +961,11 @@ public class ImportReplay extends PlainImporterBase
 		String symbology = thisOne.getSymbology();
 		if (symbology != null && !symbology.isEmpty() && symbology.length() > 2)
 		{
-			shapeWrapper.setLineStyle(ImportReplay.replayLineStyleFor(symbology
+			shapeWrapper.getShape().setLineStyle(ImportReplay.replayLineStyleFor(symbology
 					.substring(2)));
 			if (symbology.length() > 3)
 			{
-				shapeWrapper.setLineThickness(ImportReplay
+				shapeWrapper.getShape().setLineWidth(ImportReplay
 						.replayLineThicknesFor(symbology.substring(3)));
 			}
 			if (symbology.length() >= 5)

--- a/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Shapes/ShapeHandler.java
+++ b/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Shapes/ShapeHandler.java
@@ -199,12 +199,12 @@ abstract public class ShapeHandler extends MWC.Utilities.ReaderWriter.XML.MWCXML
     // line style?
     if(_lineStyle != null)
     {
-    	sw.setLineStyle(_lineStyle.intValue());
+    	sw.getShape().setLineStyle(_lineStyle.intValue());
     }
     // line width?
     if(_lineThickness != null)
     {
-    	sw.setLineThickness(_lineThickness.intValue());
+    	sw.getShape().setLineWidth(_lineThickness.intValue());
     }
     sw.setVisible(_isVisible);
     sw.setLabelVisible(_labelVisible);
@@ -251,13 +251,13 @@ abstract public class ShapeHandler extends MWC.Utilities.ReaderWriter.XML.MWCXML
     TimeRangeHandler.exportThis(sw.getStartDTG(), sw.getEndDTG(), theShape, doc);
     
     // does it have an unusual line style?
-    if(sw.getLineStyle() != CanvasType.SOLID)
+    if(sw.getShape().getLineStyle() != CanvasType.SOLID)
     {
-      theShape.setAttribute(LINE_STYLE, writeThis(sw.getLineStyle()));
+      theShape.setAttribute(LINE_STYLE, writeThis(sw.getShape().getLineStyle()));
     }
     
     // and output the line thickness
-    theShape.setAttribute(LINE_THICKNESS, writeThis(sw.getLineThickness()));
+    theShape.setAttribute(LINE_THICKNESS, writeThis(sw.getShape().getLineWidth()));
 
     // and the font
     final java.awt.Font theFont = sw.getFont();

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/ShapeWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/ShapeWrapper.java
@@ -309,8 +309,7 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 				final MWC.GUI.Editable et = (MWC.GUI.Editable) ps;
 				if (et.hasEditor() == true)
 				{
-					final BeanInfo[] res =
-					{ et.getInfo() };
+					final BeanInfo[] res = { et.getInfo() };
 					return res;
 				}
 			}
@@ -323,8 +322,8 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 		{
 			// just add the reset color field first
 			final Class<?> c = ShapeWrapper.class;
-			final MethodDescriptor[] mds =
-			{ method(c, "exportThis", null, "Export Shape") };
+			final MethodDescriptor[] mds = { method(c, "exportThis", null,
+					"Export Shape") };
 			return mds;
 		}
 
@@ -339,15 +338,17 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 		{
 			try
 			{
-				final PropertyDescriptor[] myRes =
-				{
+				final PropertyDescriptor[] myRes = {
 						displayProp("LabelColor", "Label color", "the text color", FORMAT),
 						prop("Label", "the text showing", FORMAT),
 						prop("Font", "the label font", FORMAT),
-						displayProp("LabelLocation", "Label location", "the relative location of the label", FORMAT),
+						displayProp("LabelLocation", "Label location",
+								"the relative location of the label", FORMAT),
 						prop("Visible", "whether this shape is visible", VISIBILITY),
-						displayProp("LabelVisible", "Label visible", "whether the label is visible", VISIBILITY),
-						displayProp("Time_Start", "Time start", "the start date time group", TEMPORAL),
+						displayProp("LabelVisible", "Label visible",
+								"whether the label is visible", VISIBILITY),
+						displayProp("Time_Start", "Time start",
+								"the start date time group", TEMPORAL),
 						displayLongProp("LineStyle", "Line style",
 								"the dot-dash style to use for plotting this shape",
 								LineStylePropertyEditor.class, FORMAT),
@@ -355,7 +356,9 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 								"the line-thickness to use for this shape",
 								MWC.GUI.Properties.LineWidthPropertyEditor.class),
 						prop("Color", "the color of the shape itself", FORMAT),
-						displayProp("TimeEnd", "Time end",
+						displayProp(
+								"TimeEnd",
+								"Time end",
 								"the end date time group \n\r(or leave blank for to use Start as Centre time)",
 								TEMPORAL), };
 				myRes[3]
@@ -527,17 +530,6 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 	// member functions
 	// //////////////////////////////////////////////////////////
 
-	/**
-	 * the style of line to use for this feature
-	 * 
-	 */
-	private int _lineStyle;
-
-	/**
-	 * the width to draw this line
-	 */
-	private int _lineWidth;
-
 	// ///////////////////////////////////////////////////////////
 	// constructor
 	// //////////////////////////////////////////////////////////
@@ -554,7 +546,7 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 
 		// set the default font
 		setFont(new Font("Sans Serif", Font.PLAIN, 9));
-		
+
 		// and the color.
 		_theLabel.setColor(theColor);
 
@@ -626,8 +618,9 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 	}
 
 	@Override
-	public void findNearestHotSpotIn(final Point cursorPos, final WorldLocation cursorLoc,
-			final ComponentConstruct currentNearest, final Layer parentLayer)
+	public void findNearestHotSpotIn(final Point cursorPos,
+			final WorldLocation cursorLoc, final ComponentConstruct currentNearest,
+			final Layer parentLayer)
 	{
 		if (_theShape instanceof HasDraggableComponents)
 		{
@@ -638,8 +631,9 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 	}
 
 	@Override
-	public void findNearestHotSpotIn(final Point cursorPos, final WorldLocation cursorLoc,
-			final LocationConstruct currentNearest, final Layer parentLayer, final Layers theData)
+	public void findNearestHotSpotIn(final Point cursorPos,
+			final WorldLocation cursorLoc, final LocationConstruct currentNearest,
+			final Layer parentLayer, final Layers theData)
 	{
 		_theShape.findNearestHotSpotIn(cursorPos, cursorLoc, currentNearest,
 				parentLayer, theData);
@@ -705,6 +699,36 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 		return _myEditor;
 	}
 
+
+	public final int getLineStyle()
+	{
+		return getShape().getLineStyle();
+	}
+
+	/**
+	 * the line thickness (convenience wrapper around width)
+	 * 
+	 * @return
+	 */
+	public int getLineThickness()
+	{
+		return getShape().getLineWidth();
+	}	
+	
+	public final void setLineStyle(final int style)
+	{
+		getShape().setLineStyle(style);
+	}
+
+	/**
+	 * the line thickness (convenience wrapper around width)
+	 */
+	public void setLineThickness(final int val)
+	{
+		getShape().setLineWidth(val);
+	}
+
+	
 	@Override
 	public final java.util.Collection<Editable> getItemsBetween(
 			final HiResDate start, final HiResDate end)
@@ -787,21 +811,6 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 		return _theLabel.getVisible();
 	}
 
-	public final int getLineStyle()
-	{
-		return _lineStyle;
-	}
-
-	/**
-	 * the line thickness (convenience wrapper around width)
-	 * 
-	 * @return
-	 */
-	public int getLineThickness()
-	{
-		return _lineWidth;
-	}
-
 	@Override
 	public final WorldLocation getLocation()
 	{
@@ -818,15 +827,13 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 	public final MWC.GenericData.Watchable[] getNearestTo(final HiResDate DTG)
 	{
 
-		MWC.GenericData.Watchable[] res = new MWC.GenericData.Watchable[]
-		{};
+		MWC.GenericData.Watchable[] res = new MWC.GenericData.Watchable[] {};
 
 		// special case, have we been asked for an invalid time period?
 		if (DTG == TimePeriod.INVALID_DATE)
 		{
 			// yes, just return ourselves
-			return new Watchable[]
-			{ this };
+			return new Watchable[] { this };
 		}
 		else
 		{
@@ -839,8 +846,7 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 					if ((getStartDTG().lessThan(DTG)) && (getEndDTG().greaterThan(DTG)))
 					{
 						// yes, it's within our time period
-						res = new MWC.GenericData.Watchable[]
-						{ this };
+						res = new MWC.GenericData.Watchable[] { this };
 					}
 					else
 					{
@@ -859,11 +865,9 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 
 					// is this within our threshold?
 					if (diff <= getThreshold())
-						res = new MWC.GenericData.Watchable[]
-						{ this };
+						res = new MWC.GenericData.Watchable[] { this };
 					else
-						res = new MWC.GenericData.Watchable[]
-						{};
+						res = new MWC.GenericData.Watchable[] {};
 				}
 			}
 			else
@@ -873,8 +877,7 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 				if (_theEndDTG == null)
 				{
 					// yup, say we were nearest
-					res = new MWC.GenericData.Watchable[]
-					{ this };
+					res = new MWC.GenericData.Watchable[] { this };
 				}
 			}// this whole object is a watchable
 
@@ -1009,13 +1012,13 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 		if (getVisible())
 		{
 			// sort out the line style
-			dest.setLineStyle(_lineStyle);
+			dest.setLineStyle(_theShape.getLineStyle());
 
 			// store the current line width
 			final float lineWid = dest.getLineWidth();
 
 			// and the line width
-			dest.setLineWidth(_lineWidth);
+			dest.setLineWidth(_theShape.getLineWidth());
 
 			// first paint the symbol
 			_theShape.paint(dest);
@@ -1117,19 +1120,6 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 		getSupport().firePropertyChange(ShapeWrapper.LABEL_VIS_CHANGED, null,
 				new Boolean(val));
 
-	}
-
-	public final void setLineStyle(final int style)
-	{
-		_lineStyle = style;
-	}
-
-	/**
-	 * the line thickness (convenience wrapper around width)
-	 */
-	public void setLineThickness(final int val)
-	{
-		_lineWidth = val;
 	}
 
 	/**


### PR DESCRIPTION
It became apparent that the line widths are being ignored.

It then became apparent that line width and style are being stored at both the shape and the shape-wrapper level.

This PR removes that duplication.