### PR TITLE
BUILD_FIX - takeout versions on  limpet update site 

### DIFF
--- a/org.mwc.debrief.targetplatforms/eclipse38.target
+++ b/org.mwc.debrief.targetplatforms/eclipse38.target
@@ -20,10 +20,10 @@
 <repository location="http://download.eclipse.org/eclipse/updates/3.8"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.geotools.feature.feature.group" version="1.0.6.201605211057"/>
-<unit id="info.limpet.feature.feature.group" version="1.0.6.201605211057"/>
-<unit id="info.limpet.rcp.feature.feature.group" version="1.0.6.201605211057"/>
-<unit id="info.limpet.ui.feature.feature.group" version="1.0.6.201605211057"/>
+<unit id="org.geotools.feature.feature.group" version="0.0.0"/>
+<unit id="info.limpet.feature.feature.group" version="0.0.0"/>
+<unit id="info.limpet.rcp.feature.feature.group" version="0.0.0"/>
+<unit id="info.limpet.ui.feature.feature.group" version="0.0.0"/>
 <repository location="http://debrief.github.io/limpet-update/1.0"/>
 </location>
 </locations>


### PR DESCRIPTION
takeout versions as limpet update site we replace than add new builds ,limpet only has latest build bundles/features    