### PR TITLE
Hotfix - breaking on empty right-click

### DIFF
--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/RightClickSupport.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/RightClickSupport.java
@@ -1092,9 +1092,12 @@ public class RightClickSupport
               }
             }
           }
-          // and a separator
-          subMenu.add(new Separator(thisCat));
-
+          
+          if (subMenu != null)
+          {
+            // and a separator
+            subMenu.add(new Separator(thisCat));
+          }
         }
       }
 


### PR DESCRIPTION
We aren't able to right-click on empty background.

We can only add a separator if we've added a sub-menu