### PR TITLE
Auto location for track name

### DIFF
--- a/org.mwc.cmap.legacy/src/MWC/GUI/Properties/NullableLocationPropertyEditor.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Properties/NullableLocationPropertyEditor.java
@@ -24,7 +24,7 @@ public class NullableLocationPropertyEditor extends LocationPropertyEditor
   {
     super.setAsText(val);
     
-    if(val.equals("Auto"))
+    if("Auto".equals(val))
       _myLocation = new Integer(AUTO);
       
   }
@@ -50,6 +50,7 @@ public class NullableLocationPropertyEditor extends LocationPropertyEditor
       res = "Centre";
       break;
     case(AUTO):
+    default:
       res = "Auto";
       break;
     }

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Properties/NullableLocationPropertyEditor.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Properties/NullableLocationPropertyEditor.java
@@ -1,0 +1,58 @@
+package MWC.GUI.Properties;
+
+public class NullableLocationPropertyEditor extends LocationPropertyEditor
+{
+  /** don't try to use a specific label location,
+   * automatically calculate the best location (according
+   * to the location of other properties, especially
+   * auto-located fix DTG labels)
+   */
+  final static public int AUTO = -1;
+
+  public String[] getTags()
+  {
+    final String tags[] = {"Top",
+                     "Bottom",
+                     "Left",
+                     "Right",
+                     "Centre",
+                     "Auto"};
+    return tags;
+  }
+  
+  public void setAsText(final String val)
+  {
+    super.setAsText(val);
+    
+    if(val.equals("Auto"))
+      _myLocation = new Integer(AUTO);
+      
+  }
+
+  public String getAsText()
+  {
+    String res = null;
+    switch(_myLocation.intValue())
+    {
+    case(TOP):
+      res = "Top";
+      break;
+    case(BOTTOM):
+      res = "Bottom";
+      break;
+    case(LEFT):
+      res = "Left";
+      break;
+    case(RIGHT):
+      res = "Right";
+      break;
+    case(CENTRE):
+      res = "Centre";
+      break;
+    case(AUTO):
+      res = "Auto";
+      break;
+    }
+    return res;
+  }
+}

--- a/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/TrackHandler.java
+++ b/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/TrackHandler.java
@@ -47,6 +47,7 @@ import Debrief.Wrappers.Track.TrackSegment;
 import Debrief.Wrappers.Track.TrackWrapper_Support.SegmentList;
 import MWC.GUI.Editable;
 import MWC.GUI.Plottable;
+import MWC.GUI.Properties.NullableLocationPropertyEditor;
 import MWC.GenericData.Duration;
 import MWC.GenericData.WorldDistance;
 import MWC.Utilities.ReaderWriter.XML.Util.ColourHandler;
@@ -86,8 +87,8 @@ public class TrackHandler extends MWC.Utilities.ReaderWriter.XML.MWCXMLReader
   /**
    * class which contains list of textual representations of label locations
    */
-  static final MWC.GUI.Properties.LocationPropertyEditor lp =
-      new MWC.GUI.Properties.LocationPropertyEditor();
+  static final NullableLocationPropertyEditor lp =
+      new NullableLocationPropertyEditor();
 
   public static void exportTrack(final Debrief.Wrappers.TrackWrapper track,
       final org.w3c.dom.Element parent, final org.w3c.dom.Document doc)

--- a/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/TrackHandler.java
+++ b/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/TrackHandler.java
@@ -87,7 +87,7 @@ public class TrackHandler extends MWC.Utilities.ReaderWriter.XML.MWCXMLReader
   /**
    * class which contains list of textual representations of label locations
    */
-  static final NullableLocationPropertyEditor lp =
+  private static final NullableLocationPropertyEditor lp =
       new NullableLocationPropertyEditor();
 
   public static void exportTrack(final Debrief.Wrappers.TrackWrapper track,

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/TrackWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/TrackWrapper.java
@@ -4636,7 +4636,7 @@ public class TrackWrapper extends MWC.GUI.PlainWrapper implements
         }
 
         // is this the one we're looking for?
-        if (thisE == splitPnt)
+        if (thisE.equals(splitPnt))
         {
           // yup, remember it - we want to use the next value
           previous = thisE;
@@ -4649,7 +4649,8 @@ public class TrackWrapper extends MWC.GUI.PlainWrapper implements
     final SortedSet<Editable> p2 = relevantSegment.tailSet(splitPnt);
 
     // get our results ready
-    final TrackSegment ts1, ts2;
+    final TrackSegment ts1;
+    final TrackSegment ts2;
 
     // aaah, just sort out if we are splitting a TMA segment, in which case
     // we

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/TrackWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/TrackWrapper.java
@@ -74,6 +74,7 @@ import MWC.GUI.Properties.FractionPropertyEditor;
 import MWC.GUI.Properties.LabelLocationPropertyEditor;
 import MWC.GUI.Properties.LineStylePropertyEditor;
 import MWC.GUI.Properties.LineWidthPropertyEditor;
+import MWC.GUI.Properties.NullableLocationPropertyEditor;
 import MWC.GUI.Properties.TimeFrequencyPropertyEditor;
 import MWC.GUI.Shapes.DraggableItem;
 import MWC.GUI.Shapes.HasDraggableComponents;
@@ -191,7 +192,7 @@ public class TrackWrapper extends MWC.GUI.PlainWrapper implements
                     VISIBILITY),
                 displayExpertLongProp("NameLocation", "Name location",
                     "relative location of track label", FORMAT,
-                    MWC.GUI.Properties.LocationPropertyEditor.class),
+                    MWC.GUI.Properties.NullableLocationPropertyEditor.class),
                 displayExpertLongProp("LabelFrequency", "Label frequency",
                     "the label frequency", TEMPORAL,
                     MWC.GUI.Properties.TimeFrequencyPropertyEditor.class),
@@ -3524,9 +3525,15 @@ public class TrackWrapper extends MWC.GUI.PlainWrapper implements
     if (this.getEndTimeLabels() && !isSinglePointTrack())
     {
       oldLoc = getNameLocation();
-      final int theLoc =
-          LabelLocationPropertyEditor.oppositeFor(hostFix.getLabelLocation());
-      setNameLocation(theLoc);
+      
+      // is it auto-locate?
+      if(oldLoc == NullableLocationPropertyEditor.AUTO)
+      {
+        // ok, automatically locate it
+        final int theLoc =
+            LabelLocationPropertyEditor.oppositeFor(hostFix.getLabelLocation());
+        setNameLocation(theLoc);
+      }
     }
 
     // and paint it


### PR DESCRIPTION
Fixes #2393 

Introduce property editor that allows a label to have an "Auto" location- such as for a track name. The track name can have a fixed location, or it can always be plotted opposite the DTG label of the first/last fix