### PR TITLE
avoid "duplicate data item" when we have sensor cuts loaded twice

### DIFF
--- a/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/ambiguity/AmbiguityResolver.java
+++ b/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/ambiguity/AmbiguityResolver.java
@@ -967,7 +967,7 @@ public class AmbiguityResolver
                 new FixedMillisecond(time.getDate().getTime());
             final TimeSeriesDataItem item =
                 new TimeSeriesDataItem(sec, combinedRate);
-            scores.add(item);
+            scores.addOrUpdate(item);
           }
 
           final String timeStr = time.getDate().toString();


### PR DESCRIPTION
Fixes #2461 