### PR TITLE
Introduce performance improvement by cacheing the label for sensor cuts

### DIFF
--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java
@@ -641,6 +641,12 @@ public final class SensorContactWrapper extends
   private boolean _hasFreq = false;
 
   private double _freq;
+  
+
+  /**
+   *  cache the date string
+   */
+  transient String _cachedName = null;
 
   /**
    * the calculation to determine if the bearing is to the port is expensive, so cache the result
@@ -1142,14 +1148,18 @@ public final class SensorContactWrapper extends
     return "Sensor:" + getSensorName() + "\nDTG:" + getName() + "\nTrack:"
         + getLabel();
   }
-
+  
   /**
    * get the name of this entry, using the formatted DTG
    */
   @Override
   public final String getName()
   {
-    return DebriefFormatDateTime.toStringHiRes(_DTG);
+    if(_cachedName == null)
+    {
+      _cachedName = DebriefFormatDateTime.toStringHiRes(_DTG);
+    }
+    return _cachedName;
   }
 
   public final WorldLocation getOrigin()
@@ -1527,6 +1537,9 @@ public final class SensorContactWrapper extends
   public final void setDTG(final HiResDate val)
   {
     _DTG = val;
+    
+    // also clear the cached name
+    _cachedName = null;
   }
 
   public final void setFrequency(final double val)


### PR DESCRIPTION
The outline view takes a long time to update after deleting lots of sensor cuts.

I analysed the performance. I didn't find the dominant cause, but I did find it is costly to generate the labels for the sensor cuts. The DTG string is formatted afresh each time.

This PR introduces the cacheing of sensor cut labels.