### PR TITLE
2685 Reduce flutter in Residuals View

### DIFF
--- a/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/StackedDotHelper.java
+++ b/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/StackedDotHelper.java
@@ -826,6 +826,7 @@ public final class StackedDotHelper
     if ((secs == null) || (secs.length == 0))
     {
       logger.logError(IStatus.INFO, "No secondary track assigned", null);
+      return;
     }
     else
     {


### PR DESCRIPTION
Fixes #2685 
We should return after throwing error, to avoid the flickering of removing the error title