### PR TITLE
Force video to re-buffer after stretch changes.

### DIFF
--- a/org.mwc.cmap.media/src/org/mwc/cmap/media/xuggle/XugglePlayer.java
+++ b/org.mwc.cmap.media/src/org/mwc/cmap/media/xuggle/XugglePlayer.java
@@ -291,6 +291,7 @@ public class XugglePlayer extends Composite {
 
 	public void setStretchMode(boolean stretchMode) {
 		this.stretchMode = stretchMode;
+		videoBuffer.repaint();
 	}
 
 	protected void firePlaying(long milli) {


### PR DESCRIPTION
From the video player from stretch to normal left traces of the stretched image behind it.

Introduce a repaint() operation to get rid of them.