### PR TITLE
M26 resize editor

### DIFF
--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/DebriefProperty.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/DebriefProperty.java
@@ -170,7 +170,11 @@ public class DebriefProperty implements IPropertyDescriptor, IDebriefProperty
     Control res = null;
     if (_myHelper != null)
     {
-      res = _myHelper.getEditorControlFor(parent, this);
+      // only create an editor control if it's not a read-only property
+      if(_thisProp.getWriteMethod() != null)
+      {
+        res = _myHelper.getEditorControlFor(parent, this);
+      }
     }
     return res;
   }
@@ -181,7 +185,11 @@ public class DebriefProperty implements IPropertyDescriptor, IDebriefProperty
     CellEditor res = null;
     if (_myHelper != null)
     {
-      res = _myHelper.getCellEditorFor(parent);
+      // only create an editor control if it's not a read-only property
+      if(_thisProp.getWriteMethod() != null)
+      {
+        res = _myHelper.getCellEditorFor(parent);
+      }
     }
     return res;
   }
@@ -260,7 +268,17 @@ public class DebriefProperty implements IPropertyDescriptor, IDebriefProperty
   {
     // find out the type of the editor
     final Method write = _thisProp.getWriteMethod();
-    return write.getAnnotations();
+    final Annotation[] res;
+    if(write != null)
+    {
+      res = write.getAnnotations();      
+    }
+    else
+    {
+      res = null;
+    }
+    
+    return res;
   }
 
   @Override
@@ -405,8 +423,11 @@ public class DebriefProperty implements IPropertyDescriptor, IDebriefProperty
     final Method write = _thisProp.getWriteMethod();
     try
     {
-      write.invoke(_subject, new Object[]
-      {theValue});
+      if (write != null)
+      {
+        write.invoke(_subject, new Object[]
+        {theValue});
+      }
     }
     catch (final IllegalArgumentException e)
     {

--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/EditableWrapper.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/EditableWrapper.java
@@ -32,6 +32,7 @@ import org.mwc.cmap.core.CorePlugin;
 
 import MWC.GUI.Editable;
 import MWC.GUI.Editable.DeprecatedPropertyDescriptor;
+import MWC.GUI.Editable.EditorType;
 import MWC.GUI.FireExtended;
 import MWC.GUI.FireReformatted;
 import MWC.GUI.Griddable;
@@ -522,7 +523,8 @@ public class EditableWrapper implements IPropertySource
   final public IPropertyDescriptor[] getPropertyDescriptors()
   {
     // right, does this object have dynamic descriptors?
-    if (_editable.getInfo() instanceof Editable.DynamicDescriptors)
+    final EditorType info = _editable.getInfo();
+    if (info instanceof Editable.DynamicDescriptors)
     {
       // yes - reset our list, we'll regenerate them
       _myDescriptors = null;
@@ -534,7 +536,7 @@ public class EditableWrapper implements IPropertySource
           new Vector<IPropertyDescriptor>(0, 1);
       final IPropertyDescriptor[] res = new IPropertyDescriptor[]
       {null};
-      final Editable.EditorType editor = _editable.getInfo();
+      final Editable.EditorType editor = info;
       if (editor != null)
       {
         final PropertyDescriptor[] properties = editor.getPropertyDescriptors();

--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/ui_support/swt/SWTCanvasAdapter.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/ui_support/swt/SWTCanvasAdapter.java
@@ -157,6 +157,8 @@ public class SWTCanvasAdapter implements CanvasType, Serializable, Editable,
     ExtendedCanvasType
 {
 
+  protected static final String EDITOR_LABEL = "Appearance";
+
   /**
    * the alpha depth of semi-transparent objects
    * 
@@ -224,7 +226,7 @@ public class SWTCanvasAdapter implements CanvasType, Serializable, Editable,
    * the current line width.
    */
   private float _lineWidth = UNSET_LINE_WIDTH;
-
+  
   /**
    * flag for whether we have the GDI library availble. The plotting algs will keep on failing if
    * it's not. We should remember when its not avaialble, and not bother calling from there on.
@@ -440,12 +442,17 @@ public class SWTCanvasAdapter implements CanvasType, Serializable, Editable,
     // check if this is a real resize
     if ((_theSize == null) || (!_theSize.equals(p1)))
     {
-
+      
+      final Dimension oldDim = _theSize;
+      
       // ok, now remember it
       _theSize = p1;
 
       // and pass it onto the projection
       _theProjection.setScreenArea(p1);
+      
+      // fire screen size updated
+      this.getInfo().fireChanged(this, DIMENSIONS, oldDim, p1);
     }
   }
 
@@ -1431,8 +1438,11 @@ public class SWTCanvasAdapter implements CanvasType, Serializable, Editable,
    */
   public final String toString()
   {
-    return "Appearance";
+    return EDITOR_LABEL;
   }
+
+  private static final String DIMENSIONS = "Dimensions";
+
 
   // ////////////////////////////////////////////////////
   // bean info for this class
@@ -1452,13 +1462,17 @@ public class SWTCanvasAdapter implements CanvasType, Serializable, Editable,
         final PropertyDescriptor[] res =
         {displayProp("BackgroundColor", "Background color",
             "the background color"), displayProp("LineThickness",
-                "Line thickness", "the line thickness"),};
+                "Line thickness", "the line thickness"),
+          displayReadOnlyProp(DIMENSIONS,
+              "Current plot size", "the editor control dimensions (read-only)")
+            };
 
         return res;
 
       }
       catch (final IntrospectionException e)
       {
+        e.printStackTrace();
         return super.getPropertyDescriptors();
       }
     }
@@ -1603,4 +1617,10 @@ public class SWTCanvasAdapter implements CanvasType, Serializable, Editable,
     }
   }
 
+  public String getDimensions()
+  {
+    Dimension dims = this.getSize();
+    return (int)dims.getWidth() + "px * " + (int)dims.getHeight() + "px";
+  }
+  
 }

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Editable.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Editable.java
@@ -741,6 +741,29 @@ public interface Editable
       p.setDisplayName(displayName);
     	return p;
     }
+    
+    /**
+     * convenience class to create a property
+     * 
+     * @param name
+     *          name of this property
+     * @param description
+     *          description of this property
+     * @param displayName
+     *          display name
+     * @return property description
+     * @throws IntrospectionException
+     *           if the methods can't be found
+     */
+    protected final PropertyDescriptor displayReadOnlyProp(final String name,
+        final String displayName, final String description) throws IntrospectionException
+    {
+      final PropertyDescriptor p = new PropertyDescriptor(name, _class, "get" + name, null);
+      p.setShortDescription(description);
+      p.setDisplayName(displayName);
+      
+      return p;
+    }
 
     /**
      * convenience class to create a property


### PR DESCRIPTION
Fixes #2883 

Ideally we wouldn't have to manually refresh the property editor on screen refresh.  But, this seems best solution so far.