### PR TITLE
Hotfix/more property fixes

### DIFF
--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/DTGHelper.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/DTGHelper.java
@@ -114,7 +114,25 @@ public class DTGHelper extends EditorHelper
 			_originalTime = _time;
 		}
 
-		protected void firePropertyChanged(final String propName)
+    @Override
+    public boolean equals(Object obj)
+    {
+      final boolean res;
+
+      if (obj instanceof DTGPropertySource)
+      {
+        DTGPropertySource o = (DTGPropertySource) obj;
+        res = this.getValue().compareTo(o.getValue()) == 0;
+      }
+      else
+      {
+        res = false;
+      }
+
+      return res;
+    }
+
+    protected void firePropertyChanged(final String propName)
 		{
 			// Control ctl = (Control)element.getControl();
 			//

--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/EditableWrapper.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/EditableWrapper.java
@@ -754,6 +754,7 @@ public class EditableWrapper implements IPropertySource
    * @see org.eclipse.ui.views.properties.IPropertySource#setPropertyValue(java.lang .Object,
    * java.lang.Object)
    */
+  @SuppressWarnings("unused")
   @Override
   final public void setPropertyValue(final Object id, final Object value)
   {

--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/EditableWrapper.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/EditableWrapper.java
@@ -777,6 +777,24 @@ public class EditableWrapper implements IPropertySource
       // SWT font.  This round trip means that identical fonts can appear to be different
       valueChanged = !fontsAreEqual((Font) value, (Font) oldVal);
     }
+    else if (thisProp != null)
+    {
+      // see if the helpers can help
+      EditorHelper helper = thisProp.getHelper();
+      
+      // do a round trip of the new value, to ensure they're of the
+      // correct type
+      Object newVal = helper.translateFromSWT(value);
+      Object toSWT = helper.translateToSWT(newVal);
+      if (toSWT != null && !toSWT.equals(oldVal))
+      {
+        valueChanged = true;
+      }
+      else
+      {
+        valueChanged = false;
+      }
+    }
     else
     {
       valueChanged = value != null && !value.equals(oldVal);

--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/LatLongHelper.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/property_support/LatLongHelper.java
@@ -82,7 +82,7 @@ public class LatLongHelper extends EditorHelper
 		return (target == WorldLocation.class);
 	}
 
-	public Object translateToSWT(final Object orig)
+  public Object translateToSWT(final Object orig)
 	{
 		final WorldLocation value = (WorldLocation) orig;
     
@@ -451,7 +451,26 @@ public class LatLongHelper extends EditorHelper
 
 			firePropertyChanged((String) propName);
 		}
+	  
 
+	  @Override
+	  public boolean equals(Object obj)
+	  {
+      final boolean res;
+	    if(obj instanceof LatLongPropertySource)
+	    {
+	      LatLongPropertySource o = (LatLongPropertySource) obj;
+
+	      // compare locations
+	      res = this.getValue().equals(o.getValue());
+	    }
+	    else
+	    {
+	      res = false;
+	    }
+	    return res;
+	  }
+		
 		public String toString()
 		{
 			String res;

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/CircleShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/CircleShape.java
@@ -367,12 +367,17 @@ public class CircleShape extends PlainShape implements Editable,
 	 */
   public void setCentre(final WorldLocation centre)
   {
+    // remember the old value of centre
+    final WorldLocation oldCentre = _theCentre;
+    
     // make the change
     _theCentre = centre;
+    
     // and calc the new summary data
     calcPoints();
+    
     // inform our listeners, including the parent (so it can move the label)
-    firePropertyChange(PlainWrapper.LOCATION_CHANGED, _theCentre, centre);
+    firePropertyChange(PlainWrapper.LOCATION_CHANGED, oldCentre, centre);
   }
 
 	/**

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/CircleShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/CircleShape.java
@@ -365,18 +365,15 @@ public class CircleShape extends PlainShape implements Editable,
 	 * @param centre
 	 *          the WorldLocation marking the centre
 	 */
-	public void setCentre(final WorldLocation centre)
-	{
-		// inform our listeners
-		firePropertyChange(PlainWrapper.LOCATION_CHANGED, _theCentre, centre);
-		// make the change
-		_theCentre = centre;
-		// and calc the new summary data
-		calcPoints();
-
-		// and inform the parent (so it can move the label)
-		firePropertyChange(PlainWrapper.LOCATION_CHANGED, null, null);
-	}
+  public void setCentre(final WorldLocation centre)
+  {
+    // make the change
+    _theCentre = centre;
+    // and calc the new summary data
+    calcPoints();
+    // inform our listeners, including the parent (so it can move the label)
+    firePropertyChange(PlainWrapper.LOCATION_CHANGED, _theCentre, centre);
+  }
 
 	/**
 	 * @return the centre of the circle

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java
@@ -742,15 +742,18 @@ public class SensorWrapper extends TacticalDataWrapper implements
 
   public void setSensorOffset(final WorldDistance.ArrayLength sensorOffset)
   {
-    _sensorOffset = sensorOffset;
-
-    if (_sensorOffset != null)
+    if (sensorOffset != null && !sensorOffset.equals(_sensorOffset))
     {
-      clearChildOffsets();
-    }
+      _sensorOffset = sensorOffset;
 
-    // ok, fire the property change
-    firePropertyChange(SensorWrapper.LOCATION_CHANGED, null, sensorOffset);
+      if (_sensorOffset != null)
+      {
+        clearChildOffsets();
+      }
+
+      // ok, fire the property change
+      firePropertyChange(SensorWrapper.LOCATION_CHANGED, null, sensorOffset);
+    }
   }
 
   /**


### PR DESCRIPTION
Again we've got some recursive property updates involving the Properties View.

We're checking if the value has actually changed prior to setting the value, but the equals() operator was missing for some data types.