### PR TITLE
hotfix - correctly assign symbol for imported text labels

### DIFF
--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/ArcShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/ArcShape.java
@@ -220,9 +220,7 @@ public class ArcShape extends CircleShape
 			final double centreBearing, final double arcWidth,
 			final boolean plotOrigin, final boolean plotSpokes)
 	{
-		super(theCentre, theRadius);
-
-		super.setName("Arc");
+		super(theCentre, theRadius, "Arc");
 
 		_centreBearing = centreBearing;
 		_arcWidth = arcWidth;

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/ChartBoundsWrapper.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/ChartBoundsWrapper.java
@@ -388,9 +388,6 @@ public class ChartBoundsWrapper extends MWC.GUI.PlainWrapper implements
 		_theLabel.setVisible(false);
 		_theLabel.setRelativeLocation(LocationPropertyEditor.TOP);
 
-		// store the name of the shape
-		_theShape.setName(getName());
-
 		_theLabel.setFont(Defaults.getScaledFont(0.8f));
 		_theLabel.setColor(theColor);
 

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/CircleShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/CircleShape.java
@@ -193,6 +193,20 @@ public class CircleShape extends PlainShape implements Editable,
 	// constructor
 	// ////////////////////////////////////////////////
 
+	 public CircleShape(WorldLocation theCentre, WorldDistance theRadius,
+	      String name)
+	  {
+	    super(0, name);
+
+	    // store the values
+	    _theCentre = theCentre;
+	    _theRadius = theRadius;
+
+	    // now represented our circle as an area
+	    calcPoints();
+	  }
+
+	
 	/**
 	 * constructor
 	 * 
@@ -217,27 +231,11 @@ public class CircleShape extends PlainShape implements Editable,
 	public CircleShape(final WorldLocation theCentre,
 			final WorldDistance theRadius)
 	{
-		super(0, "Circle");
-
-		// store the values
-		_theCentre = theCentre;
-		_theRadius = theRadius;
-
-		// now represented our circle as an area
-		calcPoints();
-
+	  this(theCentre, theRadius, "Circle");
 	}
 
-	// public CircleShape(){
-	// // scrap, in case we are serializing
-	// _theArea = null;
-	// }
 
-	// ////////////////////////////////////////////////
-	// member functions
-	// ////////////////////////////////////////////////
-
-	public void paint(final CanvasType dest)
+  public void paint(final CanvasType dest)
 	{
 
 		// are we visible?

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/EllipseShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/EllipseShape.java
@@ -230,8 +230,6 @@ public class EllipseShape extends PlainShape implements Editable
 
     // now represented our Ellipse as an area
     calcPoints();
-
-    setName("Ellipse");
   }
   //////////////////////////////////////////////////
   // member functions

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/FurthestOnCircleShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/FurthestOnCircleShape.java
@@ -209,8 +209,6 @@ public class FurthestOnCircleShape extends PlainShape implements Editable
 
 		// store the corners of the area,
 		calcPoints();
-
-		setName("Range Ring");
 	}
 
 	// ////////////////////////////////////////////////

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/PlainShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/PlainShape.java
@@ -207,7 +207,7 @@ abstract public class PlainShape implements Serializable, DraggableItem
   /**
    * the name of this shape
    */
-  private String _myName;
+  protected String _myName;
 
   /**
    * property change support for this shape, this allows us to store a list of objects which are
@@ -266,7 +266,7 @@ abstract public class PlainShape implements Serializable, DraggableItem
     sb.append("Shape");
     sb.append(System.currentTimeMillis());
 
-    setName(sb.toString());
+    _myName = myType;
 
     // sort the default font
     setFont(Defaults.getFont());
@@ -502,17 +502,6 @@ abstract public class PlainShape implements Serializable, DraggableItem
   public void setLineWidth(final int lineWidth)
   {
     _lineWidth = lineWidth;
-  }
-
-  /**
-   * setter function for name
-   * 
-   * @param val
-   *          String representing name of shape
-   */
-  final public void setName(final String val)
-  {
-    _myName = val;
   }
 
   public void setSemiTransparent(final boolean semiTransparent)

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/PolygonShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/PolygonShape.java
@@ -724,4 +724,10 @@ public class PolygonShape extends PlainShape implements Editable,
     firePropertyChange(PlainWrapper.LOCATION_CHANGED, null, null);
   }
 
+  @Override
+  public void setName(String val)
+  {
+    _myName = val;
+  }
+
 }

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/RangeRingShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/RangeRingShape.java
@@ -251,8 +251,6 @@ public class RangeRingShape extends PlainShape implements Editable
 
 		// store the corners of the area,
 		calcPoints();
-
-		setName("Range Ring");
 	}
 
 	// ////////////////////////////////////////////////

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/WheelShape.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Shapes/WheelShape.java
@@ -274,8 +274,6 @@ public class WheelShape extends PlainShape implements Editable
 
 		// store the corners of the area,
 		calcPoints();
-
-		setName("Wheel");
 	}
 
 	/**

--- a/org.mwc.debrief.editable.test/src/org/mwc/debrief/editable/test/EditableTests.java
+++ b/org.mwc.debrief.editable.test/src/org/mwc/debrief/editable/test/EditableTests.java
@@ -109,7 +109,6 @@ import MWC.GenericData.WorldLocation;
 import MWC.GenericData.WorldSpeed;
 import MWC.GenericData.WorldVector;
 import MWC.TacticalData.Fix;
-import junit.framework.Assert;
 import junit.framework.TestCase;
 
 public class EditableTests extends TestCase
@@ -751,7 +750,7 @@ public class EditableTests extends TestCase
                                 // | Settings | File Templates.
         }
         // check it worked
-        Assert.assertNotNull("we didn't create the custom editor for:",
+        assertNotNull("we didn't create the custom editor for:",
             newInstance);
       }
       else
@@ -766,12 +765,12 @@ public class EditableTests extends TestCase
 				catch (Exception e)
 				{
 					org.mwc.debrief.editable.test.Activator.log(e);
-					Assert.fail("problem fetching property editors for " + toBeTested.getClass());
+					fail("problem fetching property editors for " + toBeTested.getClass());
 				}
 
         if (pd == null)
         {
-          Assert.fail("problem fetching property editors for " + toBeTested.getClass());
+          fail("problem fetching property editors for " + toBeTested.getClass());
           return;
         }
 
@@ -794,13 +793,13 @@ public class EditableTests extends TestCase
 					catch (Exception e)
 					{
 						org.mwc.debrief.editable.test.Activator.log(e);
-						Assert.fail("problem fetching griddable property editors for "
+						fail("problem fetching griddable property editors for "
 								+ toBeTested.getClass());
 					}
 
 					if (pd == null)
 					{
-						Assert.fail("problem fetching griddable property editors for "
+						fail("problem fetching griddable property editors for "
 								+ toBeTested.getClass());
 						return;
 					}
@@ -820,7 +819,7 @@ public class EditableTests extends TestCase
         final MethodDescriptor method = methods[thisM];
         final Method thisOne = method.getMethod();
         final String theName = thisOne.getName();
-        Assert.assertNotNull(theName);
+        assertNotNull(theName);
       }
     }
   }

--- a/org.mwc.debrief.editable.test/src/org/mwc/debrief/editable/test/EditableTests.java
+++ b/org.mwc.debrief.editable.test/src/org/mwc/debrief/editable/test/EditableTests.java
@@ -26,9 +26,6 @@ import java.net.URL;
 import java.util.Date;
 import java.util.Vector;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
@@ -59,6 +56,14 @@ import org.mwc.debrief.satc_interface.data.SATC_Solution;
 import org.mwc.debrief.satc_interface.data.wrappers.BMC_Wrapper;
 import org.mwc.debrief.satc_interface.data.wrappers.FMC_Wrapper;
 import org.osgi.framework.Bundle;
+
+import com.bbn.openmap.layer.vpf.LibrarySelectionTable;
+import com.planetmayo.debrief.satc.model.contributions.BearingMeasurementContribution;
+import com.planetmayo.debrief.satc.model.contributions.CoreMeasurementContribution.CoreMeasurement;
+import com.planetmayo.debrief.satc.model.contributions.FrequencyMeasurementContribution;
+import com.planetmayo.debrief.satc.model.generator.ISolver;
+import com.planetmayo.debrief.satc.model.manager.ISolversManager;
+import com.planetmayo.debrief.satc_rcp.SATC_Activator;
 
 import ASSET.GUI.SuperSearch.Plotters.SSGuiSupport;
 import ASSET.GUI.Workbench.Plotters.ScenarioParticipantWrapper;
@@ -104,14 +109,8 @@ import MWC.GenericData.WorldLocation;
 import MWC.GenericData.WorldSpeed;
 import MWC.GenericData.WorldVector;
 import MWC.TacticalData.Fix;
-
-import com.bbn.openmap.layer.vpf.LibrarySelectionTable;
-import com.planetmayo.debrief.satc.model.contributions.BearingMeasurementContribution;
-import com.planetmayo.debrief.satc.model.contributions.CoreMeasurementContribution.CoreMeasurement;
-import com.planetmayo.debrief.satc.model.contributions.FrequencyMeasurementContribution;
-import com.planetmayo.debrief.satc.model.generator.ISolver;
-import com.planetmayo.debrief.satc.model.manager.ISolversManager;
-import com.planetmayo.debrief.satc_rcp.SATC_Activator;
+import junit.framework.Assert;
+import junit.framework.TestCase;
 
 public class EditableTests extends TestCase
 {
@@ -477,7 +476,6 @@ public class EditableTests extends TestCase
 			final HiResDate theDTG = new HiResDate(new java.util.Date().getTime());
 			final EllipseShape theEllipse = new EllipseShape(origin, 45, new WorldDistance(
 					10, WorldDistance.DEGS), new WorldDistance(5, WorldDistance.DEGS));
-			theEllipse.setName("test ellipse");
 			editable = new TMAContactWrapper("blank sensor",
 					"blank track", theDTG, origin, 5d, 6d, 1d, Color.pink, "my label",
 					theEllipse, "some symbol");
@@ -718,13 +716,13 @@ public class EditableTests extends TestCase
     // check if we received an object
   	System.out.println("testing " + toBeTested.getClass());
 
-    Assert.assertNotNull("Found editable object", toBeTested);
+    assertNotNull("Found editable object", toBeTested);
 
     final Editable.EditorType et = toBeTested.getInfo();
 
     if (et == null)
     {
-      Assert.fail("no editor type returned for");
+      fail("no editor type returned for");
       return;
     }
 

--- a/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportPeriodText.java
+++ b/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportPeriodText.java
@@ -65,7 +65,6 @@
 // Initial revision
 //
 
-
 package Debrief.ReaderWriter.Replay;
 
 import java.text.ParseException;
@@ -115,13 +114,13 @@ final class ImportPeriodText extends AbstractPlainLineImporter
     // start with the symbology
     symbology = st.nextToken();
 
-		// combine the date, a space, and the time
-		final String dateToken = st.nextToken();
-		final String timeToken = st.nextToken();
+    // combine the date, a space, and the time
+    final String dateToken = st.nextToken();
+    final String timeToken = st.nextToken();
 
-		// and extract the date
-		theDate = DebriefFormatDateTime.parseThis(dateToken, timeToken);
-		
+    // and extract the date
+    theDate = DebriefFormatDateTime.parseThis(dateToken, timeToken);
+
     // combine the date, a space, and the time
     dateStr = st.nextToken() + " " + st.nextToken();
 
@@ -131,77 +130,75 @@ final class ImportPeriodText extends AbstractPlainLineImporter
     // now the location
     try
     {
-    	latDeg = MWCXMLReader.readThisDouble(st.nextToken());
-    	latMin = MWCXMLReader.readThisDouble(st.nextToken());
-    	latSec = MWCXMLReader.readThisDouble(st.nextToken());
+      latDeg = MWCXMLReader.readThisDouble(st.nextToken());
+      latMin = MWCXMLReader.readThisDouble(st.nextToken());
+      latSec = MWCXMLReader.readThisDouble(st.nextToken());
 
-	    /** now, we may have trouble here, since there may not be
-	     * a space between the hemisphere character and a 3-digit
-	     * latitude value - so BE CAREFUL
-	     */
-	    final String vDiff = st.nextToken();
-	    if (vDiff.length() > 3)
-	    {
-	      // hmm, they are combined
-	      latHem = vDiff.charAt(0);
-	      final String secondPart = vDiff.substring(1, vDiff.length());
-	      longDeg = MWCXMLReader.readThisDouble(secondPart);
-	    }
-	    else
-	    {
-	      // they are separate, so only the hem is in this one
-	      latHem = vDiff.charAt(0);
-	      longDeg = MWCXMLReader.readThisDouble(st.nextToken());
-	    }
-	    longMin = MWCXMLReader.readThisDouble(st.nextToken());
-	    longSec = MWCXMLReader.readThisDouble(st.nextToken());
-	    longHem = st.nextToken().charAt(0);
+      /**
+       * now, we may have trouble here, since there may not be a space between the hemisphere
+       * character and a 3-digit latitude value - so BE CAREFUL
+       */
+      final String vDiff = st.nextToken();
+      if (vDiff.length() > 3)
+      {
+        // hmm, they are combined
+        latHem = vDiff.charAt(0);
+        final String secondPart = vDiff.substring(1, vDiff.length());
+        longDeg = MWCXMLReader.readThisDouble(secondPart);
+      }
+      else
+      {
+        // they are separate, so only the hem is in this one
+        latHem = vDiff.charAt(0);
+        longDeg = MWCXMLReader.readThisDouble(st.nextToken());
+      }
+      longMin = MWCXMLReader.readThisDouble(st.nextToken());
+      longSec = MWCXMLReader.readThisDouble(st.nextToken());
+      longHem = st.nextToken().charAt(0);
 
-	    final String depthStr = st.nextToken();
-	    try
-	    {
-	      theDepth = MWCXMLReader.readThisDouble(depthStr);
-	    }
-	    catch (final ParseException e)
-	    {
-	      // hey, it didn't contain a double, just use it as a text string
-	      theText = depthStr;
-	    }
+      final String depthStr = st.nextToken();
+      try
+      {
+        theDepth = MWCXMLReader.readThisDouble(depthStr);
+      }
+      catch (final ParseException e)
+      {
+        // hey, it didn't contain a double, just use it as a text string
+        theText = depthStr;
+      }
 
-	    if (st.hasMoreTokens())
-	    {
-	      // if we haven't read in part of the message already, read in the remainder
-	      if (theText != null)
-	      {
-	        // and now read in the remainder of the line, and append to the message
-	        theText += " " + st.nextToken("\r").trim();
-	      }
-	      else
-	      {
-	        // and now read in the message, we have already read the depth
-	        theText = st.nextToken("\r").trim();
-	      }
-	    }
+      if (st.hasMoreTokens())
+      {
+        // if we haven't read in part of the message already, read in the remainder
+        if (theText != null)
+        {
+          // and now read in the remainder of the line, and append to the message
+          theText += " " + st.nextToken("\r").trim();
+        }
+        else
+        {
+          // and now read in the message, we have already read the depth
+          theText = st.nextToken("\r").trim();
+        }
+      }
 
-	    // create the tactical data
-	    theLoc = new WorldLocation(latDeg, latMin, latSec, latHem,
-	                               longDeg, longMin, longSec, longHem,
-	                               theDepth);
+      // create the tactical data
+      theLoc = new WorldLocation(latDeg, latMin, latSec, latHem, longDeg,
+          longMin, longSec, longHem, theDepth);
 
-	    // create the fix ready to store it
-	    final LabelWrapper lw = new LabelWrapper(theText,
-	                                       theLoc,
-	                                       ImportReplay.replayColorFor(symbology),
-	                                       theDate,
-	                                       theOtherDate);
-	
-	    return lw;
+      // create the fix ready to store it
+      final LabelWrapper lw = new LabelWrapper(theText, theLoc, ImportReplay
+          .replayColorFor(symbology), theDate, theOtherDate);
+
+      final String symType = ImportReplay.replayTrackSymbolFor(symbology);
+      lw.setSymbolType(symType);
+
+      return lw;
     }
-    catch(final ParseException pe)
+    catch (final ParseException pe)
     {
-    	MWC.Utilities.Errors.Trace.trace(pe,
-				"Whilst import PeriodText");
-		return null;
+      MWC.Utilities.Errors.Trace.trace(pe, "Whilst import PeriodText");
+      return null;
     }
   }
 
@@ -216,7 +213,8 @@ final class ImportPeriodText extends AbstractPlainLineImporter
   /**
    * export the specified shape as a string
    *
-   * @param theWrapper the Shape we are exporting
+   * @param theWrapper
+   *          the Shape we are exporting
    * @return the shape in String form
    */
   public final String exportThis(final MWC.GUI.Plottable theWrapper)
@@ -227,21 +225,25 @@ final class ImportPeriodText extends AbstractPlainLineImporter
 
     final TimePeriod theTime = theLabel.getTimePeriod();
 
-    line = _myType + " " + ImportReplay.replaySymbolFor(theLabel.getColor(), theLabel.getSymbolType());
-    line = line + " " + MWC.Utilities.TextFormatting.DebriefFormatDateTime.toStringHiRes(theTime.getStartDTG());
-    line = line + " " + MWC.Utilities.TextFormatting.DebriefFormatDateTime.toStringHiRes(theTime.getEndDTG());
-    line = line + " " + MWC.Utilities.TextFormatting.DebriefFormatLocation.toString(theLabel.getLocation());
+    line = _myType + " " + ImportReplay.replaySymbolFor(theLabel.getColor(),
+        theLabel.getSymbolType());
+    line = line + " " + MWC.Utilities.TextFormatting.DebriefFormatDateTime
+        .toStringHiRes(theTime.getStartDTG());
+    line = line + " " + MWC.Utilities.TextFormatting.DebriefFormatDateTime
+        .toStringHiRes(theTime.getEndDTG());
+    line = line + " " + MWC.Utilities.TextFormatting.DebriefFormatLocation
+        .toString(theLabel.getLocation());
 
     line = line + " " + theLabel.getLabel();
 
     return line;
   }
 
-
   /**
    * indicate if you can export this type of object
    *
-   * @param val the object to test
+   * @param val
+   *          the object to test
    * @return boolean saying whether you can do it
    */
   public final boolean canExportThis(final Object val)
@@ -254,7 +256,8 @@ final class ImportPeriodText extends AbstractPlainLineImporter
       final LabelWrapper lw = (LabelWrapper) val;
 
       // does it have a time period?
-      if ((lw.getTimePeriod() != null) && (lw.getTimePeriod().getStartDTG() != null))
+      if ((lw.getTimePeriod() != null) && (lw.getTimePeriod()
+          .getStartDTG() != null))
       {
         // yes, this is a label with only the start time specified,
         // we can export it
@@ -267,11 +270,3 @@ final class ImportPeriodText extends AbstractPlainLineImporter
   }
 
 }
-
-
-
-
-
-
-
-

--- a/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportPeriodText.java
+++ b/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportPeriodText.java
@@ -77,6 +77,7 @@ import MWC.GenericData.WorldLocation;
 import MWC.Utilities.ReaderWriter.AbstractPlainLineImporter;
 import MWC.Utilities.ReaderWriter.XML.MWCXMLReader;
 import MWC.Utilities.TextFormatting.DebriefFormatDateTime;
+import MWC.Utilities.TextFormatting.DebriefFormatLocation;
 
 /**
  * class to parse a label from a line of text
@@ -227,12 +228,11 @@ final class ImportPeriodText extends AbstractPlainLineImporter
 
     line = _myType + " " + ImportReplay.replaySymbolFor(theLabel.getColor(),
         theLabel.getSymbolType());
-    line = line + " " + MWC.Utilities.TextFormatting.DebriefFormatDateTime
-        .toStringHiRes(theTime.getStartDTG());
-    line = line + " " + MWC.Utilities.TextFormatting.DebriefFormatDateTime
-        .toStringHiRes(theTime.getEndDTG());
-    line = line + " " + MWC.Utilities.TextFormatting.DebriefFormatLocation
-        .toString(theLabel.getLocation());
+    line = line + " " + DebriefFormatDateTime.toStringHiRes(theTime
+        .getStartDTG());
+    line = line + " " + DebriefFormatDateTime.toStringHiRes(theTime
+        .getEndDTG());
+    line = line + " " + DebriefFormatLocation.toString(theLabel.getLocation());
 
     line = line + " " + theLabel.getLabel();
 

--- a/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportTimeText.java
+++ b/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportTimeText.java
@@ -62,7 +62,6 @@
 // Initial revision
 //
 
-
 package Debrief.ReaderWriter.Replay;
 
 import java.text.ParseException;
@@ -75,17 +74,21 @@ import MWC.Utilities.ReaderWriter.AbstractPlainLineImporter;
 import MWC.Utilities.ReaderWriter.XML.MWCXMLReader;
 import MWC.Utilities.TextFormatting.DebriefFormatDateTime;
 
-/** class to parse a label from a line of text
+/**
+ * class to parse a label from a line of text
  */
 final class ImportTimeText extends AbstractPlainLineImporter
 {
-  /** the type for this string
+  /**
+   * the type for this string
    */
   private final String _myType = ";TIMETEXT:";
 
-  /** read in this string and return a Label
+  /**
+   * read in this string and return a Label
    */
-  public final Object readThisLine(final String theLine){
+  public final Object readThisLine(final String theLine)
+  {
 
     // get a stream from the string
     final StringTokenizer st = new StringTokenizer(theLine);
@@ -96,7 +99,7 @@ final class ImportTimeText extends AbstractPlainLineImporter
     char latHem, longHem;
     double latSec, longSec;
     String theText;
-		HiResDate theDate=null;
+    HiResDate theDate = null;
 
     // skip the comment identifier
     st.nextToken();
@@ -104,122 +107,121 @@ final class ImportTimeText extends AbstractPlainLineImporter
     // start with the symbology
     symbology = st.nextToken();
 
-		// combine the date, a space, and the time
-		final String dateToken = st.nextToken();
-		final String timeToken = st.nextToken();
+    // combine the date, a space, and the time
+    final String dateToken = st.nextToken();
+    final String timeToken = st.nextToken();
 
-		// and extract the date
-		theDate = DebriefFormatDateTime.parseThis(dateToken, timeToken);
-	
-	try
-	{
-		// now the location
-		latDeg = MWCXMLReader.readThisDouble(st.nextToken());
-		latMin = MWCXMLReader.readThisDouble(st.nextToken());
-		latSec = MWCXMLReader.readThisDouble(st.nextToken());
+    // and extract the date
+    theDate = DebriefFormatDateTime.parseThis(dateToken, timeToken);
 
-	    /** now, we may have trouble here, since there may not be
-	     * a space between the hemisphere character and a 3-digit
-	     * latitude value - so BE CAREFUL
-	     */
-	    final String vDiff = st.nextToken();
-	    if(vDiff.length() > 3)
-	    {
-	      // hmm, they are combined
-	      latHem = vDiff.charAt(0);
-	      final String secondPart = vDiff.substring(1, vDiff.length());
-	      longDeg  = MWCXMLReader.readThisDouble(secondPart);
-	    }
-	    else
-	    {
-	      // they are separate, so only the hem is in this one
-	      latHem = vDiff.charAt(0);
-	      longDeg = MWCXMLReader.readThisDouble(st.nextToken());
-	    }
-	    longMin = MWCXMLReader.readThisDouble(st.nextToken());
-	    longSec = MWCXMLReader.readThisDouble(st.nextToken());
-	    longHem = st.nextToken().charAt(0);
+    try
+    {
+      // now the location
+      latDeg = MWCXMLReader.readThisDouble(st.nextToken());
+      latMin = MWCXMLReader.readThisDouble(st.nextToken());
+      latSec = MWCXMLReader.readThisDouble(st.nextToken());
 
-	    // and now read in the message
-	    theText = st.nextToken("\r").trim();
-	
-	    // create the tactical data
-	    theLoc = new WorldLocation(latDeg, latMin, latSec, latHem,
-	                               longDeg, longMin, longSec, longHem,
-	                               0);
-	
-	    // create the fix ready to store it
-	    final LabelWrapper lw = new LabelWrapper(theText,
-	                                       theLoc,
-	                                       ImportReplay.replayColorFor(symbology),
-																				 theDate,
-																				 null);
-	
-	    return lw;
-	}
-	catch(final ParseException pe)
-	{
-		MWC.Utilities.Errors.Trace.trace(pe,
-				"Whilst import TimeText");
-		return null;
-	}
+      /**
+       * now, we may have trouble here, since there may not be a space between the hemisphere
+       * character and a 3-digit latitude value - so BE CAREFUL
+       */
+      final String vDiff = st.nextToken();
+      if (vDiff.length() > 3)
+      {
+        // hmm, they are combined
+        latHem = vDiff.charAt(0);
+        final String secondPart = vDiff.substring(1, vDiff.length());
+        longDeg = MWCXMLReader.readThisDouble(secondPart);
+      }
+      else
+      {
+        // they are separate, so only the hem is in this one
+        latHem = vDiff.charAt(0);
+        longDeg = MWCXMLReader.readThisDouble(st.nextToken());
+      }
+      longMin = MWCXMLReader.readThisDouble(st.nextToken());
+      longSec = MWCXMLReader.readThisDouble(st.nextToken());
+      longHem = st.nextToken().charAt(0);
+
+      // and now read in the message
+      theText = st.nextToken("\r").trim();
+
+      // create the tactical data
+      theLoc = new WorldLocation(latDeg, latMin, latSec, latHem, longDeg,
+          longMin, longSec, longHem, 0);
+
+      // create the fix ready to store it
+      final LabelWrapper lw = new LabelWrapper(theText, theLoc, ImportReplay
+          .replayColorFor(symbology), theDate, null);
+
+      // update the symbol
+      final String symType = ImportReplay.replayTrackSymbolFor(symbology);
+      lw.setSymbolType(symType);
+
+      return lw;
+    }
+    catch (final ParseException pe)
+    {
+      MWC.Utilities.Errors.Trace.trace(pe, "Whilst import TimeText");
+      return null;
+    }
   }
 
-  /** determine the identifier returning this type of annotation
+  /**
+   * determine the identifier returning this type of annotation
    */
-  public final String getYourType(){
+  public final String getYourType()
+  {
     return _myType;
   }
 
-	/** export the specified shape as a string
-	 * @return the shape in String form
-	 * @param theWrapper the Shape we are exporting
-	 */
-	public final String exportThis(final MWC.GUI.Plottable theWrapper)
-	{
-		final LabelWrapper theLabel = (LabelWrapper) theWrapper;
+  /**
+   * export the specified shape as a string
+   * 
+   * @return the shape in String form
+   * @param theWrapper
+   *          the Shape we are exporting
+   */
+  public final String exportThis(final MWC.GUI.Plottable theWrapper)
+  {
+    final LabelWrapper theLabel = (LabelWrapper) theWrapper;
 
-		String line=null;
+    String line = null;
 
-		line = _myType + " BB ";
-		line = line + MWC.Utilities.TextFormatting.DebriefFormatLocation.toString(theLabel.getLocation());
+    line = _myType + " BB ";
+    line = line + MWC.Utilities.TextFormatting.DebriefFormatLocation.toString(
+        theLabel.getLocation());
 
-		line = line + theLabel.getLabel();
+    line = line + theLabel.getLabel();
 
-		return line;
-	}
+    return line;
+  }
 
+  /**
+   * indicate if you can export this type of object
+   * 
+   * @param val
+   *          the object to test
+   * @return boolean saying whether you can do it
+   */
+  public final boolean canExportThis(final Object val)
+  {
+    boolean res = false;
 
-	/** indicate if you can export this type of object
-	 * @param val the object to test
-	 * @return boolean saying whether you can do it
-	 */
-	public final boolean canExportThis(final Object val)
-	{
-		boolean res = false;
+    if (val instanceof LabelWrapper)
+    {
+      // also see if there is just the start time specified
+      final LabelWrapper lw = (LabelWrapper) val;
+      if ((lw.getStartDTG() != null) && (lw.getEndDTG() == null))
+      {
+        // yes, this is a label with only the start time specified,
+        // we can export it
+        res = true;
+      }
+    }
 
-		if(val instanceof LabelWrapper)
-		{
-			// also see if there is just the start time specified
-			final LabelWrapper lw = (LabelWrapper)val;
-			if((lw.getStartDTG() != null) && (lw.getEndDTG() == null))
-			{
-				// yes, this is a label with only the start time specified,
-				// we can export it
-				res = true;
-			}
-		}
+    return res;
 
-		return res;
-
-	}
+  }
 
 }
-
-
-
-
-
-
-
-

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/ShapeWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/ShapeWrapper.java
@@ -542,9 +542,6 @@ public class ShapeWrapper extends MWC.GUI.PlainWrapper implements
 		// store the shape
 		_theShape = theShape;
 
-		// store the name of the shape
-		_theShape.setName(getName());
-
 		// set the default font
 		setFont(Defaults.getFont());
 

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java
@@ -1337,7 +1337,6 @@ public final class TMAContactWrapper extends
 			final HiResDate theDTG = new HiResDate(new java.util.Date().getTime());
 			final EllipseShape theEllipse = new EllipseShape(origin, 45, new WorldDistance(
 					10, WorldDistance.DEGS), new WorldDistance(5, WorldDistance.DEGS));
-			theEllipse.setName("test ellipse");
 			final TMAContactWrapper ed_abs = new TMAContactWrapper("blank sensor",
 					"blank track", theDTG, origin, 5d, 6d, 1d, Color.pink, "my label",
 					theEllipse, "some symbol");


### PR DESCRIPTION
I've just noticed that the symbol attribute gets ignored when we're importing text labels