### PR TITLE
Hotfix/can't filter dynamic shape set

### DIFF
--- a/org.mwc.cmap.combined.feature/root_installs/sample_data/boat_1_2_arcs.rep
+++ b/org.mwc.cmap.combined.feature/root_installs/sample_data/boat_1_2_arcs.rep
@@ -45,8 +45,8 @@
 ;SENSORARC: 951212 055000 951212 060000 NELSON @C 0 360 700 1200 CZ_Ring
 ;;
 ;; sensor coverage with null finish - visible permanently from start time
-;SENSORARC: 951212 080000 NULL COLLINGWOOD @@ -135 -45 0 1000 -20 20 0 1000 45 135 0 1000 160 -160 0 1000  "Cross beams null finish"
+;SENSORARC: 951212 080000 NULL COLLINGWOOD @B -135 -45 0 1000 -20 20 0 1000 45 135 0 1000 160 -160 0 1000  "Cross beams null finish"
 ;; sensor coverage with null start - visible permanently until end time
-;SENSORARC: NULL 951212 070000 COLLINGWOOD @@ -135 -45 1100 2000 45 135 1100 2000 "Beams null start"
+;SENSORARC: NULL 951212 070000 COLLINGWOOD @C -135 -45 1100 2000 45 135 1100 2000 "Beams null start"
 ;; sensor coverage with null times - visible permanently 
-;SENSORARC: NULL NULL COLLINGWOOD @@ -135 -45 2100 3000 45 135 2100 3000 "Beams null start & finish"
+;SENSORARC: NULL NULL COLLINGWOOD @D -135 -45 2100 3000 45 135 2100 3000 "Beams null start & finish"

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/DynamicTrackShapes/DynamicTrackShapeSetWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/DynamicTrackShapes/DynamicTrackShapeSetWrapper.java
@@ -14,8 +14,10 @@
  */
 package Debrief.Wrappers.DynamicTrackShapes;
 
+import java.awt.Color;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
+import java.util.Collection;
 import java.util.Enumeration;
 
 import Debrief.Wrappers.TrackWrapper;
@@ -24,13 +26,15 @@ import MWC.GUI.CanvasType;
 import MWC.GUI.DynamicPlottable;
 import MWC.GUI.Editable;
 import MWC.GUI.FireReformatted;
+import MWC.GUI.Shapes.Symbols.PlainSymbol;
 import MWC.GenericData.HiResDate;
 import MWC.GenericData.TimePeriod;
 import MWC.GenericData.TimePeriod.BaseTimePeriod;
+import MWC.GenericData.Watchable;
 import MWC.GenericData.WatchableList;
 
 public class DynamicTrackShapeSetWrapper extends BaseLayer implements
-    Cloneable, DynamicPlottable
+    Cloneable, DynamicPlottable, WatchableList
 {
   // //////////////////////////////////////////////////////////////////////////
   // embedded class, used for editing the projection
@@ -366,6 +370,58 @@ public class DynamicTrackShapeSetWrapper extends BaseLayer implements
     {
       add(item);
     }
+  }
+
+  @Override
+  public Color getColor()
+  {
+    return Color.RED;
+  }
+
+  @Override
+  public HiResDate getStartDTG()
+  {
+    throw new IllegalArgumentException("Method not implemented for DynamicTrackShapeSetWrapper");
+  }
+
+  @Override
+  public HiResDate getEndDTG()
+  {
+    throw new IllegalArgumentException("Method not implemented for DynamicTrackShapeSetWrapper");
+  }
+
+  @Override
+  public Watchable[] getNearestTo(HiResDate DTG)
+  {
+    throw new IllegalArgumentException("Method not implemented for DynamicTrackShapeSetWrapper");
+  }
+
+  @Override
+  public void filterListTo(HiResDate start, HiResDate end)
+  {
+    TimePeriod period = new TimePeriod.BaseTimePeriod(start, end);
+    Enumeration<Editable> iter = elements();
+    while(iter.hasMoreElements())
+    {
+      final DynamicTrackShapeWrapper item = (DynamicTrackShapeWrapper) iter.nextElement();
+      final HiResDate thisStart = item.getStartDTG();
+      if(thisStart != null)
+      {
+        item.setVisible(period.contains(thisStart));
+      }
+    }
+  }
+
+  @Override
+  public Collection<Editable> getItemsBetween(HiResDate start, HiResDate end)
+  {
+    throw new IllegalArgumentException("Method not implemented for DynamicTrackShapeSetWrapper");
+  }
+
+  @Override
+  public PlainSymbol getSnailShape()
+  {
+    throw new IllegalArgumentException("Method not implemented for DynamicTrackShapeSetWrapper");
   }
 
 }


### PR DESCRIPTION
A class-cast exception was thrown as I was playing with Sensor Arcs, because the track was unable to filter it's child data when it contained sensor arcs.