### PR TITLE
Hotfix - remove mistaken invite to generate track

### DIFF
--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTrackFromActiveCuts.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTrackFromActiveCuts.java
@@ -267,7 +267,7 @@ public class GenerateTrackFromActiveCuts implements RightClickContextItemGenerat
 				}
 			}
 		}
-		else
+		else if(subjects.length > 1)
 		{
 			// more than one item = maybe it's a series of sensor cuts
 			


### PR DESCRIPTION
We mistakenly offer to create active track when nothing is selected