### PR TITLE
Hotfix to avoid NPE as TimeController closes

### DIFF
--- a/org.mwc.cmap.TimeController/src/org/mwc/cmap/TimeController/views/TimeController.java
+++ b/org.mwc.cmap.TimeController/src/org/mwc/cmap/TimeController/views/TimeController.java
@@ -1714,7 +1714,7 @@ public class TimeController extends ViewPart implements ISelectionProvider,
           public void eventTriggered(final String type, final Object part,
               final IWorkbenchPart parentPart)
           {
-            if (_layerPainterManager != part)
+            if (!part.equals(_layerPainterManager))
             {
               // ok, insert the painter mode actions, together with
               // our standard
@@ -1732,7 +1732,7 @@ public class TimeController extends ViewPart implements ISelectionProvider,
           public void eventTriggered(final String type, final Object part,
               final IWorkbenchPart parentPart)
           {
-            if (_layerPainterManager.equals(part))
+            if (part.equals(_layerPainterManager))
             {
               _layerPainterManager = null;
             }


### PR DESCRIPTION
Avoid NPE in TimeController as it tries to update when the app is closing