### PR TITLE
hotfix - file loaders broken

### DIFF
--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/AISLoader.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/AISLoader.java
@@ -30,7 +30,7 @@ import MWC.GUI.Layers;
 public class AISLoader extends CoreLoader
 {
 
-  public AISLoader(String fileType)
+  public AISLoader()
   {
     super("AIS", null);
   }

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/GPXLoader.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/GPXLoader.java
@@ -30,7 +30,7 @@ import MWC.GUI.Layers;
  */
 public class GPXLoader extends CoreLoader
 {
-  public GPXLoader(String fileType)
+  public GPXLoader()
   {
     super("GPX", "gpx");
   }

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/MsDocXLoader.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/MsDocXLoader.java
@@ -13,7 +13,7 @@ import MWC.TacticalData.TrackDataProvider;
 public class MsDocXLoader extends CoreLoader
 {
 
-  public MsDocXLoader(String fileType)
+  public MsDocXLoader()
   {
     super(".docx", ".docx");
   }

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/NMEALoader.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/NMEALoader.java
@@ -32,7 +32,7 @@ import MWC.GUI.Layers;
 public class NMEALoader extends CoreLoader
 {
 
-  public NMEALoader(String fileType)
+  public NMEALoader()
   {
     super("NMEA", null);
   }

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/PdfLoader.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/PdfLoader.java
@@ -13,7 +13,7 @@ import MWC.GUI.Layers;
 public class PdfLoader extends CoreLoader
 {
 
-  public PdfLoader(String fileType)
+  public PdfLoader()
   {
     super("pdf", "pdf");
   }

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/ReplayLoader.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/ReplayLoader.java
@@ -35,9 +35,9 @@ import MWC.GUI.Layers;
 public class ReplayLoader extends CoreLoader
 {
 
-  public ReplayLoader(String fileType)
+  public ReplayLoader()
   {
-    super("Replay", null);
+    super("Replay", ".rep");
   }
 
   /**

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/SATCLoader.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/SATCLoader.java
@@ -31,7 +31,7 @@ import MWC.GUI.Layers;
 public class SATCLoader extends CoreLoader
 {
 
-  public SATCLoader(String fileType)
+  public SATCLoader()
   {
     super("SATC Scenario", null);
   }

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/SATCSampleLoader.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/loaders/SATCSampleLoader.java
@@ -44,7 +44,7 @@ import MWC.Utilities.TextFormatting.GMTDateFormat;
 public class SATCSampleLoader extends CoreLoader
 {
 
-  public SATCSampleLoader(String fileType)
+  public SATCSampleLoader()
   {
     super("SATC Sample", null);
   }


### PR DESCRIPTION
Fix, we accidentally introduce parameters for these constructors, which prevented them from being generated by prop-file configuration