### PR TITLE
Hotfix/stacked dot click diagnostics

### DIFF
--- a/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BaseStackedDotsView.java
+++ b/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BaseStackedDotsView.java
@@ -1307,7 +1307,8 @@ abstract public class BaseStackedDotsView extends ViewPart implements
     setZoneChartsVisible(_showZones.isChecked());
   }
 
-  protected static Runnable getDeleteAmbiguousCutsOperation()
+  @SuppressWarnings("static-method")
+  protected Runnable getDeleteAmbiguousCutsOperation()
   {
     // ditch, let the child class(es) override it
     return null;
@@ -2296,7 +2297,8 @@ abstract public class BaseStackedDotsView extends ViewPart implements
    *
    * @return
    */
-  protected static Runnable getDeleteCutsOperation()
+  @SuppressWarnings("static-method")
+  protected Runnable getDeleteCutsOperation()
   {
     return null;
   }
@@ -2327,7 +2329,8 @@ abstract public class BaseStackedDotsView extends ViewPart implements
    *
    * @return
    */
-  protected static Runnable getResolveAmbiguityOperation()
+  @SuppressWarnings("static-method")
+  protected Runnable getResolveAmbiguityOperation()
   {
     return null;
   }

--- a/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BaseStackedDotsView.java
+++ b/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BaseStackedDotsView.java
@@ -1307,7 +1307,7 @@ abstract public class BaseStackedDotsView extends ViewPart implements
     setZoneChartsVisible(_showZones.isChecked());
   }
 
-  protected Runnable getDeleteAmbiguousCutsOperation()
+  protected static Runnable getDeleteAmbiguousCutsOperation()
   {
     // ditch, let the child class(es) override it
     return null;
@@ -2296,7 +2296,7 @@ abstract public class BaseStackedDotsView extends ViewPart implements
    *
    * @return
    */
-  protected Runnable getDeleteCutsOperation()
+  protected static Runnable getDeleteCutsOperation()
   {
     return null;
   }
@@ -2327,7 +2327,7 @@ abstract public class BaseStackedDotsView extends ViewPart implements
    *
    * @return
    */
-  protected Runnable getResolveAmbiguityOperation()
+  protected static Runnable getResolveAmbiguityOperation()
   {
     return null;
   }
@@ -2567,7 +2567,7 @@ abstract public class BaseStackedDotsView extends ViewPart implements
     operationHistory.setLimit(undoContext, 100);
   }
 
-  protected List<Zone> legsFromZigs(final long startTime, final long endTime,
+  protected static List<Zone> legsFromZigs(final long startTime, final long endTime,
       final List<Zone> zigs, final ColorProvider randomProv)
   {
     final List<Zone> legs = new ArrayList<Zone>();

--- a/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BaseStackedDotsView.java
+++ b/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BaseStackedDotsView.java
@@ -1581,12 +1581,19 @@ abstract public class BaseStackedDotsView extends ViewPart implements
             }
             else
             {
-              System.err.println("Couldn't find:" + targetSeries);
+              CorePlugin.logError(Status.WARNING,
+                  "Failed to find series:" + targetSeries, null);
               nearest = null;
             }
 
             // did we find one?
-            if (nearest != null)
+            if (nearest == null)
+            {
+              CorePlugin.logError(Status.WARNING,
+                  "Failed to find match in series:" + targetSeries + " at time:"
+                      + newDate, null);
+            }
+            else
             {
               // ok, get the editor
               final IWorkbench wb = PlatformUI.getWorkbench();


### PR DESCRIPTION
Improved diagnostics for when clicking on an error in Stacked Dots doesn't work.

We now send message to Error Log if a series (or matching item) can't be found.