### PR TITLE
Use the path to the correct app icon

### DIFF
--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/DebriefLiteApp.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/DebriefLiteApp.java
@@ -166,7 +166,7 @@ public class DebriefLiteApp implements FileDropListener
     theFrame = new JRibbonFrame(appName 
         + " (" + Debrief.GUI.VersionInfo.getVersion()+ ")");
     theFrame.setApplicationIcon(ImageWrapperResizableIcon.getIcon(MenuUtils
-        .createImage("images/icon_533.png"), MenuUtils.ICON_SIZE_32));
+        .createImage("icons/icon_256.png"), MenuUtils.ICON_SIZE_32));
     
     final GeoToolMapRenderer geoMapRenderer = new GeoToolMapRenderer();
     geoMapRenderer.loadMapContent();


### PR DESCRIPTION
We lost the app icon for D-Lite.

This PR puts it back in - by referring the correct image.

Fixes #3696