### PR TITLE
3703 resize to fit new track

### DIFF
--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/DebriefLiteApp.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/DebriefLiteApp.java
@@ -35,6 +35,7 @@ import javax.swing.SwingUtilities;
 import org.geotools.map.MapContent;
 import org.geotools.swing.JMapPane;
 import org.mwc.debrief.lite.gui.DebriefLiteToolParent;
+import org.mwc.debrief.lite.gui.FitToWindow;
 import org.mwc.debrief.lite.gui.GeoToolMapProjection;
 import org.mwc.debrief.lite.gui.LiteStepControl;
 import org.mwc.debrief.lite.gui.custom.JXCollapsiblePane.Direction;
@@ -151,8 +152,8 @@ public class DebriefLiteApp implements FileDropListener
     //set the substance look and feel
     JFrame.setDefaultLookAndFeelDecorated(true);
     SubstanceCortex.GlobalScope.setSkin(new BusinessBlueSteelSkin());
-    DisplaySplash splashScreen = new DisplaySplash(5);
-    Thread t = new Thread(splashScreen);
+    final DisplaySplash splashScreen = new DisplaySplash(5);
+    final Thread t = new Thread(splashScreen);
     t.start();
     try
     {
@@ -367,6 +368,10 @@ public class DebriefLiteApp implements FileDropListener
             {
               timeManager.setTime(source, period.getStartDTG(), true);
             }
+            
+            // and the spatial bounds
+            FitToWindow fitMe = new FitToWindow(_theLayers, mapPane);
+            fitMe.actionPerformed(null);
           }
         });
       }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/FitToWindow.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/FitToWindow.java
@@ -1,0 +1,50 @@
+package org.mwc.debrief.lite.gui;
+
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.swing.JMapPane;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import MWC.GUI.Layers;
+import MWC.GenericData.WorldArea;
+import MWC.GenericData.WorldLocation;
+
+public class FitToWindow extends AbstractAction
+{
+  /**
+   *
+   */
+  private static final long serialVersionUID = 1L;
+  private final Layers _layers;
+  private final JMapPane _map;
+
+  public FitToWindow(final Layers layers, final JMapPane map)
+  {
+    _layers = layers;
+    _map = map;
+  }
+
+  @Override
+  public void actionPerformed(final ActionEvent e)
+  {
+    final WorldArea area = _layers.getBounds();
+    if (area != null)
+    {
+      final WorldLocation tl = area.getTopLeft();
+      final WorldLocation br = area.getBottomRight();
+      final CoordinateReferenceSystem crs = _map.getMapContent()
+          .getCoordinateReferenceSystem();
+      final ReferencedEnvelope bounds = new ReferencedEnvelope(tl.getLong(), br
+          .getLong(), tl.getLat(), br.getLat(), crs);
+      _map.getMapContent().getViewport().setBounds(bounds);
+
+      // force repaint
+      final ReferencedEnvelope paneArea = _map.getDisplayArea();
+      _map.setDisplayArea(paneArea);
+    }
+  }
+
+}

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ZoomOut.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ZoomOut.java
@@ -1,0 +1,52 @@
+package org.mwc.debrief.lite.gui;
+
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.geom.Point2D;
+
+import javax.swing.AbstractAction;
+import javax.swing.JComponent;
+
+import org.geotools.geometry.DirectPosition2D;
+import org.geotools.geometry.Envelope2D;
+import org.geotools.swing.JMapPane;
+
+import com.vividsolutions.jts.geom.Coordinate;
+
+public class ZoomOut extends AbstractAction
+{
+  /**
+   *
+   */
+  private static final long serialVersionUID = 1L;
+  private final JMapPane _map;
+
+  public ZoomOut(final JMapPane map)
+  {
+    _map = map;
+  }
+
+  @Override
+  public void actionPerformed(final ActionEvent e)
+  {
+    final Rectangle paneArea = ((JComponent) _map).getVisibleRect();
+
+    // get the centre of the viewport
+    final Coordinate centre = _map.getMapContent().getViewport().getBounds()
+        .centre();
+    final Point2D mapPos = new Point2D.Double(centre.x, centre.y);
+
+    // decide on a new scale
+    final double scale = _map.getWorldToScreenTransform().getScaleX();
+    final double newScale = scale / 1.5;
+
+    final DirectPosition2D corner = new DirectPosition2D(centre.x - 0.5d
+        * paneArea.getWidth() / newScale, centre.y + 0.5d * paneArea.getHeight()
+            / newScale);
+
+    final Envelope2D newMapArea = new Envelope2D();
+    newMapArea.setFrameFromCenter(mapPos, corner);
+    _map.setDisplayArea(newMapArea);
+  }
+
+}

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/menu/DebriefRibbon.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/menu/DebriefRibbon.java
@@ -34,7 +34,7 @@ public class DebriefRibbon
   {
     // add menus here
     DebriefRibbonFile.addFileTab(ribbon, geoMapRenderer);
-    DebriefRibbonView.addViewTab(ribbon, geoMapRenderer);
+    DebriefRibbonView.addViewTab(ribbon, geoMapRenderer, layers);
     DebriefRibbonInsert.addInsertTab(ribbon, geoMapRenderer, layers,
         null, parent);
     DebriefRibbonTimeController.addTimeControllerTab(ribbon, geoMapRenderer, stepControl, timeManager);

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/menu/DebriefRibbonView.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/menu/DebriefRibbonView.java
@@ -4,11 +4,13 @@ import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.swing.AbstractAction;
+
 import org.geotools.swing.JMapPane;
 import org.geotools.swing.action.PanAction;
-import org.geotools.swing.action.ResetAction;
 import org.geotools.swing.action.ZoomInAction;
-import org.geotools.swing.action.ZoomOutAction;
+import org.mwc.debrief.lite.gui.FitToWindow;
+import org.mwc.debrief.lite.gui.ZoomOut;
 import org.mwc.debrief.lite.map.GeoToolMapRenderer;
 import org.pushingpixels.flamingo.api.ribbon.JRibbon;
 import org.pushingpixels.flamingo.api.ribbon.JRibbonBand;
@@ -18,24 +20,28 @@ import org.pushingpixels.flamingo.api.ribbon.resize.CoreRibbonResizePolicies;
 import org.pushingpixels.flamingo.api.ribbon.resize.CoreRibbonResizePolicies.IconRibbonBandResizePolicy;
 import org.pushingpixels.flamingo.api.ribbon.resize.RibbonBandResizePolicy;
 
+import MWC.GUI.Layers;
+
 public class DebriefRibbonView
 {
   protected static void addViewTab(final JRibbon ribbon,
-      final GeoToolMapRenderer _geoMapRenderer)
+      final GeoToolMapRenderer _geoMapRenderer, final Layers layers)
   {
     final JRibbonBand viewBand = new JRibbonBand("View", null);
     final JMapPane mapPane = (JMapPane) _geoMapRenderer.getMap();
+    final AbstractAction doFit = new FitToWindow(layers, mapPane);
+        
     viewBand.startGroup();
     MenuUtils.addCommand("Pan", "images/16/hand.png", new PanAction(mapPane),
         viewBand, RibbonElementPriority.TOP);
     final ZoomInAction zoomInAction = new ZoomInAction(mapPane);
     MenuUtils.addCommand("Zoom In", "images/16/zoomin.png", zoomInAction,
         viewBand, RibbonElementPriority.TOP);
-    MenuUtils.addCommand("Zoom Out", "images/16/zoomout.png", new ZoomOutAction(
-        mapPane), viewBand, RibbonElementPriority.TOP);
     viewBand.startGroup();
+    MenuUtils.addCommand("Zoom Out", "images/16/zoomout.png", new ZoomOut(
+        mapPane), viewBand, RibbonElementPriority.TOP);
     MenuUtils.addCommand("Fit to Window", "images/16/fit_to_win.png",
-        new ResetAction(mapPane), viewBand, null);
+        doFit, viewBand, null);
     final List<RibbonBandResizePolicy> policies = new ArrayList<>();
     policies.add(new CoreRibbonResizePolicies.Mirror(viewBand));
     policies.add(new CoreRibbonResizePolicies.Mid2Low(viewBand));
@@ -45,7 +51,6 @@ public class DebriefRibbonView
     ribbon.addTask(fileTask);
 
     // lastly, run the zoom-in event, to put the map into that mode
-    // put the map into zoom mode
     zoomInAction.actionPerformed(new ActionEvent(viewBand,
         ActionEvent.ACTION_PERFORMED, "Click"));
   }


### PR DESCRIPTION
Fixes  #3703

Also changes behaviour of two map buttons:
* fit to window - refits to show the currently loaded data
* zoom out - instantly performs action, centred on the current plot