### PR TITLE
allow Debrief to import Ellipse2 entries again

### DIFF
--- a/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportReplay.java
+++ b/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportReplay.java
@@ -739,7 +739,7 @@ public class ImportReplay extends PlainImporterBase
       _coreImporters.addElement(new ImportLine());
       _coreImporters.addElement(new ImportVector());
       _coreImporters.addElement(new ImportEllipse());
-      //_coreImporters.addElement(new ImportEllipse2());
+      _coreImporters.addElement(new ImportEllipse2());
       _coreImporters.addElement(new ImportPeriodText());
       _coreImporters.addElement(new ImportTimeText());
       _coreImporters.addElement(new ImportFixFormatter());


### PR DESCRIPTION
Loading `shapes.rep` was failing in the EASE dev branch, because this line was commented out.