### PR TITLE
3731 draw rotated text

### DIFF
--- a/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/CanvasAdaptor.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/CanvasAdaptor.java
@@ -330,10 +330,12 @@ public class CanvasAdaptor implements MWC.GUI.CanvasType {
 
 	}
 
-	@Override
-	public void drawText(final String str, final int x, final int y, final float rotate) {
-		
-	}
+  @Override
+  public void drawText(final String str, final int x, final int y,
+      final float rotate)
+  {
+    drawText(str, x, y, rotate, true);
+  }
 
 	@Override
 	public void setFont(final Font theFont)
@@ -341,9 +343,18 @@ public class CanvasAdaptor implements MWC.GUI.CanvasType {
 		_dest.setFont(theFont);
 	}
 
-	@Override
-	public void drawText(String str, int x, int y, float rotate, boolean above)
-	{
-		
-	}
+  @Override
+  public void drawText(String str, int x, int y, float rotate, boolean above)
+  {
+    if (_dest instanceof Graphics2D)
+    {
+      final Graphics2D g2d = (Graphics2D) _dest;
+
+      g2d.translate((float) x, (float) y);
+      g2d.rotate(Math.toRadians(rotate));
+      g2d.drawString(str, 0, 0);
+      g2d.rotate(-Math.toRadians(rotate));
+      g2d.translate(-(float) x, -(float) y);
+    }
+  }
 }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/DebriefLiteApp.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/DebriefLiteApp.java
@@ -227,7 +227,11 @@ public class DebriefLiteApp implements FileDropListener
     {
       // ignore
     }
-    
+
+    // for legacy integration we need to provide a tool-parent
+    final LiteParent theParent = new LiteParent();
+    Trace.initialise(theParent);
+
     defaultTitle = appName 
         + " (" + Debrief.GUI.VersionInfo.getVersion()+ ")";
     theFrame = new JRibbonFrame(defaultTitle);

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/LiteParent.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/LiteParent.java
@@ -1,0 +1,65 @@
+package org.mwc.debrief.lite;
+
+import java.util.Map;
+
+import MWC.GUI.Tools.Action;
+
+public class LiteParent implements MWC.GUI.ToolParent
+{
+
+  @Override
+  public void logError(int status, String text, Exception e)
+  {
+    throw new IllegalArgumentException("not implemented (yet)");
+  }
+
+  @Override
+  public void logError(int status, String text, Exception e, boolean revealLog)
+  {
+    throw new IllegalArgumentException("not implemented (yet)");
+  }
+
+  @Override
+  public void logStack(int status, String text)
+  {
+    throw new IllegalArgumentException("not implemented (yet)");
+  }
+
+  @Override
+  public void setCursor(int theCursor)
+  {
+    throw new IllegalArgumentException("not implemented (yet)");
+  }
+
+  @Override
+  public void restoreCursor()
+  {
+    throw new IllegalArgumentException("not implemented (yet)");
+  }
+
+  @Override
+  public void addActionToBuffer(Action theAction)
+  {
+    throw new IllegalArgumentException("not implemented (yet)");
+  }
+
+  @Override
+  public String getProperty(String name)
+  {
+    System.err.println("Failed to return property:" + name
+        + " (LiteParent not yet implemented)");
+    return null;
+  }
+
+  @Override
+  public Map<String, String> getPropertiesLike(String pattern)
+  {
+    throw new IllegalArgumentException("not implemented (yet)");
+  }
+
+  @Override
+  public void setProperty(String name, String value)
+  {
+    throw new IllegalArgumentException("not implemented (yet)");
+  }
+}


### PR DESCRIPTION
Fixes #3731 

But, incomplete. We still need to centre the text. The current algorithm starts the text at the supplied cords - it should be centered on those coords.

Rest of fix is detailed at #3835 