### PR TITLE
4576 Errors after resizing

### DIFF
--- a/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/Highlighters/PlotHighlighter.java
+++ b/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/Highlighters/PlotHighlighter.java
@@ -191,42 +191,45 @@ public interface PlotHighlighter extends Editable
         // convert to screen coordinates
         final Point tl = proj.toScreen(wa.getTopLeft());
 
-        final int tlx = tl.x;
-        final int tly = tl.y;
-
-        final Point br = proj.toScreen(wa.getBottomRight());
-        // get the width
-        final int x = tlx - _mySize;
-        final int y = tly - _mySize;
-        final int wid = (br.x - tlx) + _mySize * 2;
-        final int ht = (br.y - tly) + _mySize * 2;
-
-        // hmm - implemented plotting the cursor differently if we're
-        // looking at interpolated data
-        Stroke oldStroke = null;
-
-        // right, lets have a look
-        if (watch instanceof InterpolatedData)
+        if (tl != null)
         {
-          final java.awt.Graphics2D g2 = (java.awt.Graphics2D) dest;
-          // right, remember what the previous cursor was
-          oldStroke = g2.getStroke();
+          final int tlx = tl.x;
+          final int tly = tl.y;
 
-          // set the new one
-          final java.awt.BasicStroke stk = SwingCanvas.getStrokeFor(
-              CanvasType.DOTTED);
-          g2.setStroke(stk);
-        }
+          final Point br = proj.toScreen(wa.getBottomRight());
+          // get the width
+          final int x = tlx - _mySize;
+          final int y = tly - _mySize;
+          final int wid = (br.x - tlx) + _mySize * 2;
+          final int ht = (br.y - tly) + _mySize * 2;
 
-        // plot the rectangle
-        dest.drawRect(x, y, wid, ht);
+          // hmm - implemented plotting the cursor differently if we're
+          // looking at interpolated data
+          Stroke oldStroke = null;
 
-        // and restore the old cursor if we have to
-        if (oldStroke != null)
-        {
-          final java.awt.Graphics2D g2 = (java.awt.Graphics2D) dest;
-          g2.setStroke(oldStroke);
-          oldStroke = null;
+          // right, lets have a look
+          if (watch instanceof InterpolatedData)
+          {
+            final java.awt.Graphics2D g2 = (java.awt.Graphics2D) dest;
+            // right, remember what the previous cursor was
+            oldStroke = g2.getStroke();
+
+            // set the new one
+            final java.awt.BasicStroke stk = SwingCanvas.getStrokeFor(
+                CanvasType.DOTTED);
+            g2.setStroke(stk);
+          }
+
+          // plot the rectangle
+          dest.drawRect(x, y, wid, ht);
+
+          // and restore the old cursor if we have to
+          if (oldStroke != null)
+          {
+            final java.awt.Graphics2D g2 = (java.awt.Graphics2D) dest;
+            g2.setStroke(oldStroke);
+            oldStroke = null;
+          }
         }
 
       }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/GeoToolMapProjection.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/GeoToolMapProjection.java
@@ -133,8 +133,8 @@ public class GeoToolMapProjection extends PlainProjection implements
   @Override
   public Point toScreen(final WorldLocation val)
   {
-    DirectPosition2D workDegs = new DirectPosition2D();
-    DirectPosition2D workScreen = new DirectPosition2D();
+    final DirectPosition2D workDegs = new DirectPosition2D();
+    final DirectPosition2D workScreen = new DirectPosition2D();
 
     Point res = null;
     // and now for the actual projection bit
@@ -144,10 +144,13 @@ public class GeoToolMapProjection extends PlainProjection implements
       try
       {
         data_transform.transform(workDegs, workDegs);
-        _view.getWorldToScreen().transform(workDegs, workScreen);
-        // output the results
-        res = new Point((int) workScreen.getCoordinate()[0], (int) workScreen
-            .getCoordinate()[1]);
+        if (_view.getWorldToScreen() != null)
+        {
+          _view.getWorldToScreen().transform(workDegs, workScreen);
+          // output the results
+          res = new Point((int) workScreen.getCoordinate()[0], (int) workScreen
+              .getCoordinate()[1]);
+        }
       }
       catch (MismatchedDimensionException | TransformException e)
       {
@@ -162,8 +165,8 @@ public class GeoToolMapProjection extends PlainProjection implements
   @Override
   public WorldLocation toWorld(final Point val)
   {
-    DirectPosition2D workDegs = new DirectPosition2D();
-    DirectPosition2D workScreen = new DirectPosition2D();
+    final DirectPosition2D workDegs = new DirectPosition2D();
+    final DirectPosition2D workScreen = new DirectPosition2D();
 
     WorldLocation res = null;
     workScreen.setLocation(val.x, val.y);

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/AdvancedZoomInTool.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/AdvancedZoomInTool.java
@@ -59,7 +59,13 @@ public class AdvancedZoomInTool extends ZoomInTool
       // if the drag was from TL to BR
       if (overallX >= 0 || overallY >= 0)
       {
-        super.onMouseReleased(ev);
+        final MapViewport view = ev.getSource().getMapContent().getViewport();
+        final ReferencedEnvelope existingArea = view.getBounds();
+        // If we are not too zoomed in
+        if (existingArea.getArea() > 1e-10)
+        {
+          super.onMouseReleased(ev);
+        }
       }
       else
       {
@@ -70,11 +76,11 @@ public class AdvancedZoomInTool extends ZoomInTool
 
   public void performZoomOut(final MapMouseEvent ev)
   {
-    /** note - there's quite a bit of code commented out in this method. 
-     * The commented out code is a partial implementation of the zoom out
-     * behaviour in Full Debrief.
+    /**
+     * note - there's quite a bit of code commented out in this method. The commented out code is a
+     * partial implementation of the zoom out behaviour in Full Debrief.
      */
-    
+
     final MapViewport view = ev.getSource().getMapContent().getViewport();
     final ReferencedEnvelope existingArea = view.getBounds();
     final DirectPosition2D startWorld = new DirectPosition2D(startPosWorld);
@@ -97,7 +103,7 @@ public class AdvancedZoomInTool extends ZoomInTool
 
     final double scaleVal = Math.sqrt((existingArea.getHeight() * existingArea
         .getWidth()) / (selectedArea.height * selectedArea.width));
-    
+
     // only allow zoom out if we're not already too far our
     if (existingArea.getArea() < 2.0E15)
     {


### PR DESCRIPTION
Fix #4576 
It fixes the cases explained.
In the case in the video, it is trying to repaint the map when it has an invalid size. I am checking it now.
Regarding the zooming in, I am preventing to a maximum zoom - in.

Aside of that, I see that when resizing a lot the application, it starts to zoom out a lot. However, I would suggest to apply this to prevent it.

https://github.com/geotools/geotools/pull/2324
Mentioned here
https://gis.stackexchange.com/questions/315396/zoom-geotools-jmappane-to-retain-data-area-on-resize

(just enabling the `fixedBoundsOnResize` after updating GeoTools)
