### PR TITLE
4619 reduce secondary track warnings

### DIFF
--- a/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/StackedDotHelper.java
+++ b/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/StackedDotHelper.java
@@ -2360,7 +2360,6 @@ public final class StackedDotHelper
     // any?
     if ((secs == null) || (secs.length == 0))
     {
-      logger.logError(IStatus.INFO, "No secondary track assigned", null);
       return;
     }
     else


### PR DESCRIPTION
Fixes #4619 

Don't bother logging the fact that there isn't a secondary track.  Now that we automatically assign the secondary track, it's less of a problem.