### PR TITLE
Hotfix zero properties message

### DIFF
--- a/org.mwc.cmap.legacy/src/MWC/GUI/Properties/AWT/AWTPropertyEditor.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Properties/AWT/AWTPropertyEditor.java
@@ -649,7 +649,7 @@ public class AWTPropertyEditor extends PlainPropertyEditor implements
    * method to indicate to user that no editors were found
    */
   @Override
-  protected void showZeroEditorsFound()
+  protected void showZeroEditorsFound(final String name)
   {
     // hey, lets do this another day@@@
   }

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Properties/AWT/AWTPropertyEditor.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Properties/AWT/AWTPropertyEditor.java
@@ -279,24 +279,13 @@ public class AWTPropertyEditor extends PlainPropertyEditor implements
    * the label to show the descriptions in
    */
   Label _info;
-
-  /////////////////////////////////////////////////////////////
-  // constructor
-  ////////////////////////////////////////////////////////////
+  
   /**
-   * the constructor,
-   *
-   * @param info
-   *          the thing we're going to edit
-   * @param parent
-   *          the properties panel we're contained in
-   * @param theChart
-   *          the chart we're looking at
-   * @param theParent
-   *          the application we're contained in
-   * @param parentLayer
-   *          the layer above us, to be updated on completion
-   * @param theLayers
+   * @param info the object we are going to edit
+   * @param parent the panel we are contained in
+   * @param theLayers where the data is
+   * @param toolParent the parent we can report to
+   * @param parentLayer the layer that contains this data
    */
   public AWTPropertyEditor(final MWC.GUI.Editable.EditorType info,
       final AWTPropertiesPanel parent, final Layers theLayers,

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Properties/PlainPropertyEditor.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Properties/PlainPropertyEditor.java
@@ -831,7 +831,7 @@ abstract public class PlainPropertyEditor implements PropertyChangeListener
     if ((_theEditors.size() == 0) && (_theCustomEditor == null))
     {
       // inform the user that this object has no editable properties
-      showZeroEditorsFound();
+      showZeroEditorsFound(theInfo.getDisplayName());
     }
 
   }
@@ -1128,7 +1128,7 @@ abstract public class PlainPropertyEditor implements PropertyChangeListener
 
   abstract protected void showMethods();
 
-  abstract protected void showZeroEditorsFound();
+  abstract protected void showZeroEditorsFound(final String objectName);
 
   /**
    * return this item as a string

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Properties/PlainPropertyEditor.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Properties/PlainPropertyEditor.java
@@ -375,13 +375,13 @@ abstract public class PlainPropertyEditor implements PropertyChangeListener
         p1 = params[0];
 
         // do we have to do our special 'double' handling?
-        if (p1.equals(double.class))
+        if (p1 != null && p1.equals(double.class))
         {
           // is the value we are going to set currently
           // a string?
           if (val.getClass().equals(String.class))
           {
-            final Double d = MWCXMLReader.readThisDouble((String) val);
+            final double d = MWCXMLReader.readThisDouble((String) val);
             final Object args2[] =
             {d};
             setter.invoke(data, args2);

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Properties/Swing/SwingPropertyEditor2.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Properties/Swing/SwingPropertyEditor2.java
@@ -912,9 +912,6 @@ public class SwingPropertyEditor2 extends PlainPropertyEditor implements
    */
   private MultiLineLabel _reportWindow;
 
-  // ///////////////////////////////////////////////////////////
-  // constructor
-  // //////////////////////////////////////////////////////////
   /**
    * @param info the object we are going to edit
    * @param parent the panel we are contained in

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Properties/Swing/SwingPropertyEditor2.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Properties/Swing/SwingPropertyEditor2.java
@@ -916,16 +916,12 @@ public class SwingPropertyEditor2 extends PlainPropertyEditor implements
   // constructor
   // //////////////////////////////////////////////////////////
   /**
-   * the constructor for our Swing property editor
-   *
-   * @param info
-   *          the object we are going to edit
-   * @param parent
-   *          the panel we are contained in
-   * @param propsPanel
-   *          JTabbedPane
-   * @param theChart
-   *          the chart we will send updates to
+   * @param info the object we are going to edit
+   * @param parent the panel we are contained in
+   * @param theLayers where the data is
+   * @param toolParent the parent we can report to
+   * @param parentLayer the layer that contains this data
+   * @param propsPanel the parent properties panel
    */
   public SwingPropertyEditor2(final MWC.GUI.Editable.EditorType info,
       final SwingPropertiesPanel parent, final Layers theLayers,
@@ -1618,9 +1614,9 @@ public class SwingPropertyEditor2 extends PlainPropertyEditor implements
    * method to indicate to user that no editors were found
    */
   @Override
-  protected void showZeroEditorsFound()
+  protected void showZeroEditorsFound(final String name)
   {
-    _main.add("Center", new JLabel("This object has no editable properties"));
+    _main.add("Center", new JLabel("No editable properties found for:" + name));
   }
 
   @Override

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/editors/painters/PlainHighlighter.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/editors/painters/PlainHighlighter.java
@@ -176,7 +176,7 @@ public class PlainHighlighter implements TemporalLayerPainter
  */
     public PlainHighlighterInfo(final PlainHighlighter data)
     {
-      super(data, "Normal", "");
+      super(data, "Normal", "Normal Highlighter");
     }
 
 /** the set of descriptions for this object

--- a/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/TotePainter.java
+++ b/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/TotePainter.java
@@ -265,7 +265,7 @@ public class TotePainter implements StepperListener, CanvasType.PaintListener,
      */
     public TotePainterInfo(final TotePainter data)
     {
-      super(data, NORMAL_NAME, "");
+      super(data, NORMAL_NAME, "Display Mode");
     }
 
     /**


### PR DESCRIPTION
The message shown when editing the Default Display Mode doesn't explain very much:
![image](https://user-images.githubusercontent.com/1108513/68207975-186f4c00-ffc8-11e9-9875-a7739ac6aefd.png)

It would be better if the dialog gave the name of the thing that didn't have any properties.  This PR gives that capability:
![image](https://user-images.githubusercontent.com/1108513/68208058-43f23680-ffc8-11e9-9766-c56a70d14ea2.png)


