### PR TITLE
Include downloaded JRE in windows distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,14 @@ before_script:
 - export DISPLAY=:99
 - sh -e /etc/init.d/xvfb start
 - sleep 3
+# modify Debrief feature to include win-64 subdirectory
+echo "root.win32.win32.x86_64 = win-64" >> org.mwc.debrief.combined.feature/build.properties
+# get a 64-bit windows JRE
+- wget -P dest https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jre_x64_windows_hotspot_11.0.5_10.zip
+# unpack it
+- tar xf OpenJD*.zip
+# move it to the target folder
+- mv OpenJD* org.mwc.debrief.combined.feature/win-64
 script: mvn clean verify -U -B -fae
 after_failure:
 - ls org.mwc.debrief.ui_test


### PR DESCRIPTION
I've come up with a strategy where for Travis builds we include a JRE with the MS-Windows dist.

It _seems_ to only take 10 seconds to download the build, and it saves having to include the JRE in our GitHub repo.