### PR TITLE
Remove legacy references to Java 1.8

### DIFF
--- a/org.mwc.asset.ScenarioController2/.classpath
+++ b/org.mwc.asset.ScenarioController2/.classpath
@@ -2,5 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.mwc.asset.ScenarioController2/.classpath
+++ b/org.mwc.asset.ScenarioController2/.classpath
@@ -2,6 +2,5 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.mwc.asset.legacy/.classpath
+++ b/org.mwc.asset.legacy/.classpath
@@ -9,10 +9,5 @@
 	<classpathentry kind="lib" path="libs/postgis_1.3.5.jar"/>
 	<classpathentry kind="lib" path="libs/postgresql-8.3-604.jdbc4.jar"/>
 	<classpathentry kind="lib" path="libs/jaxen-1.1.3.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
-		<accessrules>
-			<accessrule kind="accessible" pattern="**"/>
-		</accessrules>
-	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.mwc.asset.legacy/.classpath
+++ b/org.mwc.asset.legacy/.classpath
@@ -9,5 +9,6 @@
 	<classpathentry kind="lib" path="libs/postgis_1.3.5.jar"/>
 	<classpathentry kind="lib" path="libs/postgresql-8.3-604.jdbc4.jar"/>
 	<classpathentry kind="lib" path="libs/jaxen-1.1.3.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.mwc.debrief.help/.classpath
+++ b/org.mwc.debrief.help/.classpath
@@ -3,6 +3,5 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="lib" path="lib/commons-net-2.2.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.mwc.debrief.help/.classpath
+++ b/org.mwc.debrief.help/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="lib" path="lib/commons-net-2.2.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
We were getting some javax.xml classpath errors.  I initially thought it was because the code couldn't a copy of javax.xml . But, then I realised it was complaining because there were multiple versions available.

I found, and then removed, the 3 instances of pulling in the Java 1.8 runtime.