### PR TITLE
Reduce calls to getBounds() during D-Lite render process

### DIFF
--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/ui_support/swt/SWTCanvasAdapter.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/ui_support/swt/SWTCanvasAdapter.java
@@ -1256,14 +1256,7 @@ public class SWTCanvasAdapter implements CanvasType, Serializable, Editable,
     while (enumer.hasMoreElements())
     {
       final CanvasType.PaintListener thisP = enumer.nextElement();
-      final WorldArea thisArea = thisP.getDataArea();
-      if (thisArea != null)
-      {
-        if (theArea == null)
-          theArea = new WorldArea(thisArea);
-        else
-          theArea.extend(thisArea);
-      }
+      theArea = WorldArea.extend(theArea, thisP.getDataArea());
     }
 
     // check we have found a valid area

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/AWT/AWTCanvas.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/AWT/AWTCanvas.java
@@ -269,14 +269,7 @@ final public class AWTCanvas extends java.awt.Canvas
     while (enumer.hasMoreElements())
     {
       final CanvasType.PaintListener thisP = (CanvasType.PaintListener) enumer.nextElement();
-      final WorldArea thisArea = thisP.getDataArea();
-      if (thisArea != null)
-      {
-        if (theArea == null)
-          theArea = new WorldArea(thisArea);
-        else
-          theArea.extend(thisArea);
-      }
+      theArea = WorldArea.extend(theArea, thisP.getDataArea());
     }
 
     // check if we've found anything

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/Swing/SwingCanvas.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/Swing/SwingCanvas.java
@@ -431,14 +431,7 @@ public class SwingCanvas extends javax.swing.JComponent
     while (enumer.hasMoreElements())
     {
       final CanvasType.PaintListener thisP = (CanvasType.PaintListener) enumer.nextElement();
-      final WorldArea thisArea = thisP.getDataArea();
-      if (thisArea != null)
-      {
-        if (theArea == null)
-          theArea = new WorldArea(thisArea);
-        else
-          theArea.extend(thisArea);
-      }
+      theArea = WorldArea.extend(theArea, thisP.getDataArea());
     }
 
     // check we have found a valid area

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Coast/Coastline.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Coast/Coastline.java
@@ -117,13 +117,7 @@ public class Coastline implements Serializable
 		while (enumer.hasMoreElements())
 		{
 			final CoastSegment seg = (CoastSegment) enumer.nextElement();
-			if (res == null)
-			{
-				res = seg.getBounds();
-			}
-			else
-				res.extend(seg.getBounds());
-
+      res = WorldArea.extend(res, seg.getBounds());
 		}
 		_myArea = res;
 	}

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Layers.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Layers.java
@@ -1161,14 +1161,7 @@ public class Layers implements Serializable, Plottable, PlottablesType
     while (it.hasNext())
     {
       final Layer thisL = (Layer) it.next();
-      final WorldArea newBounds = thisL.getBounds();
-      if (newBounds != null)
-      {
-        if (res == null)
-          res = new WorldArea(newBounds);
-        else
-          res.extend(newBounds);
-      }
+      res = WorldArea.extend(res, thisL.getBounds());
     }
 
     return res;

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Plottables.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Plottables.java
@@ -386,16 +386,7 @@ public class Plottables implements Plottable, Serializable, PlottablesType,
 				// is this item visible?
 				if (thisOne.getVisible())
 				{
-					final WorldArea thisA = thisOne.getBounds();
-					if (thisA != null)
-						if (res == null)
-						{
-							res = new WorldArea(thisA);
-						}
-						else
-						{
-							res.extend(thisOne.getBounds());
-						}
+		      res = WorldArea.extend(res, thisOne.getBounds());
 				}
 			}
 		}

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Tools/Operations/WriteVRML.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Tools/Operations/WriteVRML.java
@@ -181,13 +181,8 @@ abstract public class WriteVRML extends MWC.GUI.Tools.PlainTool
 			for(int i=0;i<num; i++)
 			{
 				final Layer l = (Layer)_theData.elementAt(i);
-				final WorldArea thisA = l.getBounds();
-				if(bounds == null)
-				{
-					bounds = thisA;
-				}
-				else
-					bounds.extend(thisA);
+
+				bounds = WorldArea.extend(bounds, l.getBounds());
 
 			}
 

--- a/org.mwc.cmap.legacy/src/MWC/GenericData/WorldArea.java
+++ b/org.mwc.cmap.legacy/src/MWC/GenericData/WorldArea.java
@@ -788,6 +788,17 @@ public final class WorldArea implements Serializable
 			ww5.extend(wa3);
 			assertTrue("Extending using area", ww5.equals(wa3));
 		}
+		
+		public final void testExtend2()
+		{
+      final WorldArea ww4 = new WorldArea(wa1);
+      final WorldArea ww5 = new WorldArea(wa1);
+
+      assertNull("Null test OK for static extend", extend(null, null));
+      assertTrue("First Null for static extend.", ww4.equals(extend(null, ww4)));
+      assertTrue("Second Null for static extend.", ww4.equals(extend(ww4, null)));
+      assertTrue("Extending using area static extend", wa3.equals(extend(ww5, wa3)));
+		}
 
 		public final void testAreaCalcs()
 		{

--- a/org.mwc.cmap.legacy/src/MWC/GenericData/WorldArea.java
+++ b/org.mwc.cmap.legacy/src/MWC/GenericData/WorldArea.java
@@ -403,6 +403,24 @@ public final class WorldArea implements Serializable
 		_bottomRight.setLong(_bottomRight.getLong() + border_degs);
 		_bottomRight.setDepth(_bottomRight.getDepth() - depth_metres);
 	}
+	
+	/**
+	 * Creates an area that contains both parameters
+	 * @param current Area a
+	 * @param newArea Area b
+	 * @return a + b
+	 */
+  public static WorldArea extend(WorldArea current, final WorldArea newArea)
+  {
+    if (newArea != null)
+    {
+      if (current == null)
+        current = new WorldArea(newArea);
+      else
+        current.extend(newArea);
+    }
+    return current;
+  }
 
 	/**
 	 * extend the area to include this new point. includes a normalise operation

--- a/org.mwc.debrief.GNDManager/src/org/mwc/debrief/gndmanager/Tracks/TrackStoreWrapper.java
+++ b/org.mwc.debrief.GNDManager/src/org/mwc/debrief/gndmanager/Tracks/TrackStoreWrapper.java
@@ -1052,14 +1052,7 @@ public class TrackStoreWrapper extends BaseLayer implements WatchableList,
 			{
 				final TrackStoreWrapper.CouchTrack thisT = (TrackStoreWrapper.CouchTrack) iter
 						.next();
-				final WorldArea thisB = thisT.getBounds();
-				if (thisB != null)
-				{
-					if (res == null)
-						res = new WorldArea(thisB);
-					else
-						res.extend(thisB);
-				}
+        res = WorldArea.extend(res, thisT.getBounds());
 			}
 		}
 

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/BuoyPatternWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/BuoyPatternWrapper.java
@@ -1197,21 +1197,7 @@ public final class BuoyPatternWrapper extends PlainWrapper implements
     {
       final Plottable thisOne = (Plottable) iter.nextElement();
 
-      final MWC.GenericData.WorldArea thisArea = thisOne.getBounds();
-
-      // ////////////////////////////
-      // first the area
-      // ////////////////////////////
-      // does this object have an area?
-      if (thisArea != null)
-      {
-        // do we have an area already?
-        if (res == null)
-          res = new WorldArea(thisArea);
-        else
-          res.extend(thisArea);
-      }
-
+      res = WorldArea.extend(res, thisOne.getBounds());
     }
 
     // store the result

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/TrackWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/TrackWrapper.java
@@ -2043,18 +2043,7 @@ public class TrackWrapper extends LightweightTrackWrapper implements
         while (iter.hasMoreElements())
         {
           final PlainWrapper sw = (PlainWrapper) iter.nextElement();
-          final WorldArea theseBounds = sw.getBounds();
-          if (theseBounds != null)
-          {
-            if (res == null)
-            {
-              res = new WorldArea(theseBounds);
-            }
-            else
-            {
-              res.extend(theseBounds);
-            }
-          }
+          res = WorldArea.extend(res, sw.getBounds());
         } // step through the sensors
       } // whether we have any sensors
 
@@ -2065,18 +2054,7 @@ public class TrackWrapper extends LightweightTrackWrapper implements
         while (iter.hasMoreElements())
         {
           final Plottable sw = (Plottable) iter.nextElement();
-          final WorldArea theseBounds = sw.getBounds();
-          if (theseBounds != null)
-          {
-            if (res == null)
-            {
-              res = new WorldArea(theseBounds);
-            }
-            else
-            {
-              res.extend(sw.getBounds());
-            }
-          }
+          res = WorldArea.extend(res, sw.getBounds());
         } // step through the sensors
       }
       // and our solution data
@@ -2086,18 +2064,7 @@ public class TrackWrapper extends LightweightTrackWrapper implements
         while (iter.hasMoreElements())
         {
           final PlainWrapper sw = (PlainWrapper) iter.nextElement();
-          final WorldArea theseBounds = sw.getBounds();
-          if (theseBounds != null)
-          {
-            if (res == null)
-            {
-              res = new WorldArea(theseBounds);
-            }
-            else
-            {
-              res.extend(sw.getBounds());
-            }
-          }
+          res = WorldArea.extend(res, sw.getBounds());
         } // step through the sensors
       } // whether we have any sensors
 

--- a/org.mwc.debrief.legacy/src/Debrief/Wrappers/TrackWrapper.java
+++ b/org.mwc.debrief.legacy/src/Debrief/Wrappers/TrackWrapper.java
@@ -2052,7 +2052,7 @@ public class TrackWrapper extends LightweightTrackWrapper implements
             }
             else
             {
-              res.extend(sw.getBounds());
+              res.extend(theseBounds);
             }
           }
         } // step through the sensors

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/GeoToolMapProjection.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/GeoToolMapProjection.java
@@ -106,12 +106,6 @@ public class GeoToolMapProjection extends PlainProjection implements
     }
   }
 
-  @Override
-  public WorldArea getDataArea()
-  {
-    return _layers.getBounds();
-  }
-
   public MathTransform getDataTransform()
   {
     return data_transform;

--- a/org.mwc.debrief.satc.integration/src/org/mwc/debrief/satc_interface/data/SATC_Solution.java
+++ b/org.mwc.debrief.satc.integration/src/org/mwc/debrief/satc_interface/data/SATC_Solution.java
@@ -856,15 +856,7 @@ public class SATC_Solution extends BaseLayer implements
         final WorldLocation end = conversions.toLocation(thisRoute.getEndPoint()
             .getCoordinate());
 
-        // is this the first area?
-        if (res == null)
-        {
-          res = new WorldArea(start, end);
-        }
-        else
-        {
-          res.extend(new WorldArea(start, end));
-        }
+        res = WorldArea.extend(res, new WorldArea(start, end));
       }
     }
 


### PR DESCRIPTION
Don't override parent getDataArea call