### PR TITLE
reset the treecache on resetting tree

### DIFF
--- a/org.mwc.cmap.legacy/src/MWC/GUI/LayerManager/Swing/SwingLayerManager.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/LayerManager/Swing/SwingLayerManager.java
@@ -1115,6 +1115,7 @@ public class SwingLayerManager extends SwingCustomEditor implements
   public void resetTree()
   {
     _myData.clear();
+    treeCache.clear();
     createAndInitializeTree();
 
   }


### PR DESCRIPTION
Fixes #4767 

Fixed by resetting the treeCache variable that caches treenodes when plot is reset.
