### PR TITLE
Remove dependency that couldn't be found

### DIFF
--- a/org.mwc.gnd.demonstrator/META-INF/MANIFEST.MF
+++ b/org.mwc.gnd.demonstrator/META-INF/MANIFEST.MF
@@ -10,8 +10,7 @@ Require-Bundle: org.eclipse.ui,
  org.mwc.debrief.legacy;bundle-version="1.0.64",
  org.mwc.cmap.legacy;bundle-version="1.0.46",
  org.mwc.cmap.core;bundle-version="1.0.65",
- javax.xml.bind;bundle-version="2.2.0" ,
- javax.xml.stream
+ javax.xml.bind;bundle-version="2.2.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: libs/postgis_1.3.5.jar,


### PR DESCRIPTION
We had a classpath dependency that couldn't be found.

But, we no longer require that dependency, so it has been removed.