### PR TITLE
Implemented undo/redo for the view actions 

### DIFF
--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/DebriefLiteApp.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/DebriefLiteApp.java
@@ -1124,7 +1124,7 @@ public class DebriefLiteApp implements FileDropListener {
 			_theLayers.fireReformatted(null);
 
 			// and the spatial bounds
-			new FitToWindow(_theLayers, mapPane, projection).actionPerformed(null);
+			new FitToWindow(_theLayers, mapPane, projection,null).actionPerformed(null);
 		} catch (final FileNotFoundException e) {
 			app.logError(ToolParent.ERROR, "Failed to read DPF File", e);
 			MWC.GUI.Dialogs.DialogFactory.showMessage("Open Debrief file", "Failed to read DPF File" + e.getMessage());
@@ -1218,7 +1218,7 @@ public class DebriefLiteApp implements FileDropListener {
 								theTote.assignWatchables(true);
 
 								// and the spatial bounds
-								final FitToWindow fitMe = new FitToWindow(_theLayers, mapPane, projection);
+								final FitToWindow fitMe = new FitToWindow(_theLayers, mapPane, projection,null);
 								fitMe.actionPerformed(null);
 							}
 						});
@@ -1491,6 +1491,31 @@ public class DebriefLiteApp implements FileDropListener {
 		newArea.normalise();
 
 		projection.setDataArea(newArea);
+	}
+	
+	public WorldArea getProjectionArea() {
+		final DirectPosition2D upperCorner = (DirectPosition2D) mapPane.getDisplayArea().getUpperCorner();
+		final DirectPosition2D bottomCorner = (DirectPosition2D) mapPane.getDisplayArea().getLowerCorner();
+
+		if (bottomCorner.getCoordinateReferenceSystem() != DefaultGeographicCRS.WGS84
+				&& upperCorner.getCoordinateReferenceSystem() != DefaultGeographicCRS.WGS84) {
+			try {
+				geoMapRenderer.getTransform().transform(upperCorner, upperCorner);
+				geoMapRenderer.getTransform().transform(bottomCorner, bottomCorner);
+			} catch (MismatchedDimensionException | TransformException e) {
+				Application.logError2(ToolParent.ERROR, "Failure in projection transform", e);
+			}
+		}
+
+		final WorldLocation topLocation = new WorldLocation(upperCorner.getY(), upperCorner.getX(), 0);
+		final WorldLocation bottomLocation = new WorldLocation(bottomCorner.getY(), bottomCorner.getX(), 0);
+		final WorldArea newArea = new WorldArea(topLocation, bottomLocation);
+		newArea.normalise();
+
+		return newArea;
+	}
+	public GeoToolMapProjection getProjection() {
+		return projection;
 	}
 
 }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/FitToWindow.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/FitToWindow.java
@@ -116,7 +116,7 @@ public class FitToWindow extends AbstractAction implements CommandAction {
 
 	@Override
 	public void actionPerformed(final ActionEvent e) {
-		viewActionDetails = new ViewAction(_map);
+		viewActionDetails = new ViewAction(_map,"Fit to window");
 		viewActionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
 		//System.out.println("Last projectionArea:"+viewActionDetails.getLastProjectionArea());
 		fitToWindow(_layers, _map, _projection);

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/FitToWindow.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/FitToWindow.java
@@ -45,8 +45,6 @@ public class FitToWindow extends AbstractAction implements CommandAction {
 	 *
 	 */
 	private static final long serialVersionUID = 1L;
-	
-	private ViewAction viewActionDetails;
 
 	public static void fitToWindow(final Layers layers, final JMapPane map, final PlainProjection projection) {
 		final WorldArea area = layers.getBounds();
@@ -99,15 +97,18 @@ public class FitToWindow extends AbstractAction implements CommandAction {
 		}
 	}
 
+	private ViewAction viewActionDetails;
+
 	private final Layers _layers;
 
 	private final JMapPane _map;
 
 	private final PlainProjection _projection;
 
-	private ToolParent _toolParent;
+	private final ToolParent _toolParent;
 
-	public FitToWindow(final Layers layers, final JMapPane map, final PlainProjection projection,final ToolParent parent) {
+	public FitToWindow(final Layers layers, final JMapPane map, final PlainProjection projection,
+			final ToolParent parent) {
 		_layers = layers;
 		_map = map;
 		_projection = projection;
@@ -116,18 +117,19 @@ public class FitToWindow extends AbstractAction implements CommandAction {
 
 	@Override
 	public void actionPerformed(final ActionEvent e) {
-		viewActionDetails = new ViewAction(_map,"Fit to window");
+		viewActionDetails = new ViewAction(_map, "Fit to window");
 		viewActionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
-		//System.out.println("Last projectionArea:"+viewActionDetails.getLastProjectionArea());
+		// System.out.println("Last
+		// projectionArea:"+viewActionDetails.getLastProjectionArea());
 		fitToWindow(_layers, _map, _projection);
 		viewActionDetails.setNewProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
-		
+
 	}
 
 	@Override
 	public void commandActivated(final CommandActionEvent e) {
 		actionPerformed(e);
-		if(viewActionDetails.isUndoable() && _toolParent != null) {
+		if (viewActionDetails.isUndoable() && _toolParent != null) {
 			_toolParent.addActionToBuffer(viewActionDetails);
 		}
 	}

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/FitToWindow.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/FitToWindow.java
@@ -23,6 +23,7 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.swing.JMapPane;
+import org.mwc.debrief.lite.DebriefLiteApp;
 import org.mwc.debrief.lite.map.LiteMapPane;
 import org.opengis.geometry.MismatchedDimensionException;
 import org.opengis.referencing.FactoryException;
@@ -44,6 +45,8 @@ public class FitToWindow extends AbstractAction implements CommandAction {
 	 *
 	 */
 	private static final long serialVersionUID = 1L;
+	
+	private ViewAction viewActionDetails;
 
 	public static void fitToWindow(final Layers layers, final JMapPane map, final PlainProjection projection) {
 		final WorldArea area = layers.getBounds();
@@ -102,20 +105,30 @@ public class FitToWindow extends AbstractAction implements CommandAction {
 
 	private final PlainProjection _projection;
 
-	public FitToWindow(final Layers layers, final JMapPane map, final PlainProjection projection) {
+	private ToolParent _toolParent;
+
+	public FitToWindow(final Layers layers, final JMapPane map, final PlainProjection projection,final ToolParent parent) {
 		_layers = layers;
 		_map = map;
 		_projection = projection;
+		_toolParent = parent;
 	}
 
 	@Override
 	public void actionPerformed(final ActionEvent e) {
+		viewActionDetails = new ViewAction(_map);
+		viewActionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
+		//System.out.println("Last projectionArea:"+viewActionDetails.getLastProjectionArea());
 		fitToWindow(_layers, _map, _projection);
+		viewActionDetails.setNewProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
+		
 	}
 
 	@Override
 	public void commandActivated(final CommandActionEvent e) {
 		actionPerformed(e);
+		if(viewActionDetails.isUndoable() && _toolParent != null) {
+			_toolParent.addActionToBuffer(viewActionDetails);
+		}
 	}
-
 }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/MapUtils.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/MapUtils.java
@@ -14,6 +14,81 @@
  *******************************************************************************/
 package org.mwc.debrief.lite.gui;
 
+import java.awt.Rectangle;
+
+import org.geotools.geometry.DirectPosition2D;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.opengis.geometry.MismatchedDimensionException;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
+
+import Debrief.GUI.Frames.Application;
+import MWC.GUI.ToolParent;
+import MWC.GenericData.WorldArea;
+import MWC.GenericData.WorldLocation;
+
 public class MapUtils {
+	
+	/**
+	 * Converts the Projection Area from lat/long to a referenced envelope
+	 * 
+	 * @param projectionArea
+	 * @param crs
+	 * @return
+	 */
+	public static ReferencedEnvelope convertToPaneArea(final WorldArea projectionArea,final CoordinateReferenceSystem crs) {
+		final WorldLocation tl = projectionArea.getTopLeft();
+		final WorldLocation br = projectionArea.getBottomRight();
+		double long1 = tl.getLong();
+		double lat1 = tl.getLat();
+		double long2 = br.getLong();
+		double lat2 = br.getLat();
+		if (crs != DefaultGeographicCRS.WGS84) {
+			try {
+				final MathTransform degsToWorld = CRS.findMathTransform(DefaultGeographicCRS.WGS84, crs);
+				final DirectPosition2D tlDegs = new DirectPosition2D(long1, lat1);
+				final DirectPosition2D brDegs = new DirectPosition2D(long2, lat2);
+				degsToWorld.transform(tlDegs, tlDegs);
+				degsToWorld.transform(brDegs, brDegs);
+				long1 = tlDegs.x;
+				lat1 = tlDegs.y;
+				long2 = brDegs.x;
+				lat2 = brDegs.y;
+
+			} catch (final FactoryException | MismatchedDimensionException | TransformException e) {
+				Application.logError2(ToolParent.ERROR, "Failure in projection transform", e);
+			}
+		}
+		final ReferencedEnvelope bounds = new ReferencedEnvelope(long1, long2, lat1, lat2, crs);
+		return bounds;
+	}
+	
+	public static WorldArea convertToWorldArea(final Rectangle currentViewArea,final CoordinateReferenceSystem crs) {
+		
+		WorldArea retval = null;
+		try {
+			final MathTransform degsToWorld = CRS.findMathTransform(DefaultGeographicCRS.WGS84, crs);
+			DirectPosition2D tldegs = new DirectPosition2D(currentViewArea.getX(),currentViewArea.getY());
+			degsToWorld.transform(tldegs, tldegs);
+			double long1 = tldegs.x;
+			double lat1 = tldegs.y;
+
+			DirectPosition2D brDegs = new DirectPosition2D(currentViewArea.getMaxX(),currentViewArea.getMaxY());
+			degsToWorld.transform(brDegs, brDegs);
+			double long2 = brDegs.x;
+			double lat2 = brDegs.y;
+			WorldLocation topLeftVal = new WorldLocation(lat1, long1, 0);
+			WorldLocation bottomRightVal = new WorldLocation(lat2,long2,0);
+			retval = new WorldArea(topLeftVal,bottomRightVal);
+
+		} catch (final FactoryException | MismatchedDimensionException | TransformException e) {
+			Application.logError2(ToolParent.ERROR, "Failure in projection transform", e);
+		}
+		return retval;
+	}
 
 }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ViewAction.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ViewAction.java
@@ -1,0 +1,81 @@
+/*
+ *    Debrief - the Open Source Maritime Analysis Application
+ *    http://debrief.info
+ *
+ *    (C) 2000-2016, Deep Blue C Technology Ltd
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the Eclipse Public License v1.0
+ *    (http://www.eclipse.org/legal/epl-v10.html)
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ */
+package org.mwc.debrief.lite.gui;
+
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.swing.MapPane;
+import org.mwc.debrief.lite.DebriefLiteApp;
+
+import MWC.GUI.Tools.Action;
+import MWC.GenericData.WorldArea;
+
+/**
+ * @author Ayesha
+ *
+ */
+public class ViewAction implements Action {
+
+	private WorldArea _lastProjectionArea;
+	private WorldArea _newProjectionArea;
+	private MapPane _map;
+	
+	public ViewAction(MapPane map) {
+		_map = map;
+	}
+	@Override
+	public void execute() {
+		resetProjectionArea(_newProjectionArea);
+	}
+
+	@Override
+	public boolean isRedoable() {
+		return true;
+	}
+
+	@Override
+	public boolean isUndoable() {
+		return true;
+	}
+
+	@Override
+	public void undo() {
+		resetProjectionArea(_lastProjectionArea);
+	}
+	public void setLastProjectionArea(WorldArea lastProjectionArea) {
+		_lastProjectionArea = lastProjectionArea;
+	}
+	public void setNewProjectionArea(WorldArea newProjectionArea) {
+		_newProjectionArea = newProjectionArea;
+	}
+	public WorldArea getLastProjectionArea() {
+		return _lastProjectionArea;
+	}
+	public WorldArea getNewProjectionArea() {
+		return _newProjectionArea;
+	}
+	
+	public void resetProjectionArea(WorldArea projectionArea) {
+		System.out.println("Setting projection area to:"+projectionArea);
+		final ReferencedEnvelope bounds = MapUtils.convertToPaneArea(projectionArea, _map.getMapContent().getCoordinateReferenceSystem());
+		_map.getMapContent().getViewport().setBounds(bounds);
+		// force repaint
+		final ReferencedEnvelope paneArea = _map.getDisplayArea();
+		_map.setDisplayArea(paneArea);
+		
+		DebriefLiteApp.getInstance().getProjection().setDataArea(projectionArea);
+		DebriefLiteApp.getInstance().updateProjectionArea();
+	}
+
+}

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ViewAction.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ViewAction.java
@@ -10,7 +10,7 @@
  *
  *    This library is distributed in the hope that it will be useful,
  *    but WITHOUT ANY WARRANTY; without even the implied warranty of
- *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 package org.mwc.debrief.lite.gui;
 
@@ -29,16 +29,25 @@ public class ViewAction implements Action {
 
 	private WorldArea _lastProjectionArea;
 	private WorldArea _newProjectionArea;
-	private MapPane _map;
+	private final MapPane _map;
 	private String _actionName;
-	
-	public ViewAction(MapPane map,String actionName) {
+
+	public ViewAction(final MapPane map, final String actionName) {
 		_map = map;
 		_actionName = actionName;
 	}
+
 	@Override
 	public void execute() {
 		resetProjectionArea(_newProjectionArea);
+	}
+
+	public WorldArea getLastProjectionArea() {
+		return _lastProjectionArea;
+	}
+
+	public WorldArea getNewProjectionArea() {
+		return _newProjectionArea;
 	}
 
 	@Override
@@ -51,40 +60,40 @@ public class ViewAction implements Action {
 		return true;
 	}
 
-	@Override
-	public void undo() {
-		resetProjectionArea(_lastProjectionArea);
-	}
-	public void setLastProjectionArea(WorldArea lastProjectionArea) {
-		_lastProjectionArea = lastProjectionArea;
-	}
-	public void setNewProjectionArea(WorldArea newProjectionArea) {
-		_newProjectionArea = newProjectionArea;
-	}
-	public WorldArea getLastProjectionArea() {
-		return _lastProjectionArea;
-	}
-	public WorldArea getNewProjectionArea() {
-		return _newProjectionArea;
-	}
-	
-	public void resetProjectionArea(WorldArea projectionArea) {
-		System.out.println("Setting projection area to:"+projectionArea);
-		final ReferencedEnvelope bounds = MapUtils.convertToPaneArea(projectionArea, _map.getMapContent().getCoordinateReferenceSystem());
+	public void resetProjectionArea(final WorldArea projectionArea) {
+		// System.out.println("Setting projection area to:"+projectionArea);
+		final ReferencedEnvelope bounds = MapUtils.convertToPaneArea(projectionArea,
+				_map.getMapContent().getCoordinateReferenceSystem());
 		_map.getMapContent().getViewport().setBounds(bounds);
 		// force repaint
 		final ReferencedEnvelope paneArea = _map.getDisplayArea();
 		_map.setDisplayArea(paneArea);
-		
+
 		DebriefLiteApp.getInstance().getProjection().setDataArea(projectionArea);
 		DebriefLiteApp.getInstance().updateProjectionArea();
 	}
-	public void setActionName(String _actionName) {
+
+	public void setActionName(final String _actionName) {
 		this._actionName = _actionName;
 	}
+
+	public void setLastProjectionArea(final WorldArea lastProjectionArea) {
+		_lastProjectionArea = lastProjectionArea;
+	}
+
+	public void setNewProjectionArea(final WorldArea newProjectionArea) {
+		_newProjectionArea = newProjectionArea;
+	}
+
+	@Override
 	public String toString() {
-		final String res = _actionName ;
+		final String res = _actionName;
 		return res;
+	}
+
+	@Override
+	public void undo() {
+		resetProjectionArea(_lastProjectionArea);
 	}
 
 }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ViewAction.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ViewAction.java
@@ -30,9 +30,11 @@ public class ViewAction implements Action {
 	private WorldArea _lastProjectionArea;
 	private WorldArea _newProjectionArea;
 	private MapPane _map;
+	private String _actionName;
 	
-	public ViewAction(MapPane map) {
+	public ViewAction(MapPane map,String actionName) {
 		_map = map;
+		_actionName = actionName;
 	}
 	@Override
 	public void execute() {
@@ -76,6 +78,13 @@ public class ViewAction implements Action {
 		
 		DebriefLiteApp.getInstance().getProjection().setDataArea(projectionArea);
 		DebriefLiteApp.getInstance().updateProjectionArea();
+	}
+	public void setActionName(String _actionName) {
+		this._actionName = _actionName;
+	}
+	public String toString() {
+		final String res = _actionName ;
+		return res;
 	}
 
 }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ZoomOut.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ZoomOut.java
@@ -50,7 +50,7 @@ public class ZoomOut extends AbstractAction implements CommandAction {
 	@Override
 	public void actionPerformed(final ActionEvent e) {
 		_currentViewArea = DebriefLiteApp.getInstance().getProjectionArea();
-		actionDetails = new ViewAction(_map);
+		actionDetails = new ViewAction(_map,"Zoom out");
 		actionDetails.setLastProjectionArea(_currentViewArea);
 		Rectangle paneArea = _map.getVisibleRect();
 		// get the centre of the viewport

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ZoomOut.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/gui/ZoomOut.java
@@ -22,7 +22,6 @@ import javax.swing.AbstractAction;
 
 import org.geotools.geometry.DirectPosition2D;
 import org.geotools.geometry.Envelope2D;
-import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.swing.JMapPane;
 import org.locationtech.jts.geom.Coordinate;
 import org.mwc.debrief.lite.DebriefLiteApp;
@@ -39,20 +38,21 @@ public class ZoomOut extends AbstractAction implements CommandAction {
 	private static final long serialVersionUID = 1L;
 	private final JMapPane _map;
 	private WorldArea _currentViewArea;
-	private ToolParent _toolParent;
+	private final ToolParent _toolParent;
 	private ViewAction actionDetails;
-	public ZoomOut(final JMapPane map,ToolParent parent) {
+
+	public ZoomOut(final JMapPane map, final ToolParent parent) {
 		_map = map;
 		_toolParent = parent;
-		
+
 	}
 
 	@Override
 	public void actionPerformed(final ActionEvent e) {
 		_currentViewArea = DebriefLiteApp.getInstance().getProjectionArea();
-		actionDetails = new ViewAction(_map,"Zoom out");
+		actionDetails = new ViewAction(_map, "Zoom out");
 		actionDetails.setLastProjectionArea(_currentViewArea);
-		Rectangle paneArea = _map.getVisibleRect();
+		final Rectangle paneArea = _map.getVisibleRect();
 		// get the centre of the viewport
 		final Coordinate centre = _map.getMapContent().getViewport().getBounds().centre();
 		final Point2D mapPos = new Point2D.Double(centre.x, centre.y);
@@ -70,10 +70,10 @@ public class ZoomOut extends AbstractAction implements CommandAction {
 			newMapArea.setFrameFromCenter(mapPos, corner);
 			_map.setDisplayArea(newMapArea);
 		}
-		
+
 		DebriefLiteApp.getInstance().updateProjectionArea();
 		actionDetails.setNewProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
-		System.out.println("Projection area after zoom/redo:"+DebriefLiteApp.getInstance().getProjectionArea());
+		System.out.println("Projection area after zoom/redo:" + DebriefLiteApp.getInstance().getProjectionArea());
 	}
 
 	@Override
@@ -109,5 +109,5 @@ public class ZoomOut extends AbstractAction implements CommandAction {
 //		DebriefLiteApp.getInstance().updateProjectionArea();
 //		System.out.println("After undo:"+DebriefLiteApp.getInstance().getProjectionArea());
 //	}
-	
+
 }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/AdvancedZoomInAction.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/AdvancedZoomInAction.java
@@ -21,6 +21,8 @@ import org.geotools.swing.action.ZoomInAction;
 import org.pushingpixels.flamingo.api.common.CommandAction;
 import org.pushingpixels.flamingo.api.common.CommandActionEvent;
 
+import MWC.GUI.ToolParent;
+
 /**
  * use our advanced zoom in tool, that also support zoom out
  *
@@ -34,13 +36,15 @@ public class AdvancedZoomInAction extends ZoomInAction implements CommandAction 
 	 */
 	private static final long serialVersionUID = 1L;
 
-	public AdvancedZoomInAction(final MapPane mapPane) {
+	private ToolParent _toolParent;
+	public AdvancedZoomInAction(final MapPane mapPane,final ToolParent parent) {
 		super(mapPane);
+		_toolParent = parent;
 	}
 
 	@Override
 	public void actionPerformed(final ActionEvent ev) {
-		getMapPane().setCursorTool(new AdvancedZoomInTool());
+		getMapPane().setCursorTool(new AdvancedZoomInTool(_toolParent));
 	}
 
 	@Override

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/AdvancedZoomInTool.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/AdvancedZoomInTool.java
@@ -35,11 +35,11 @@ public class AdvancedZoomInTool extends ZoomInTool {
 	private final Point startPosDevice;
 	private final Point2D startPosWorld;
 	private boolean dragged;
-	private ToolParent _toolParent;
-	
+	private final ToolParent _toolParent;
+
 	private ViewAction actionDetails;
 
-	public AdvancedZoomInTool(ToolParent parent) {
+	public AdvancedZoomInTool(final ToolParent parent) {
 		super();
 		startPosDevice = new Point();
 		startPosWorld = new DirectPosition2D();
@@ -50,11 +50,11 @@ public class AdvancedZoomInTool extends ZoomInTool {
 	@Override
 	public void onMouseClicked(final MapMouseEvent e) {
 		if (e.getButton() != MouseEvent.BUTTON3) {
-			actionDetails = new ViewAction(getMapPane(),"Zoom In");
+			actionDetails = new ViewAction(getMapPane(), "Zoom In");
 			actionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
 			super.onMouseClicked(e);
 			actionDetails.setNewProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
-			if(actionDetails.isUndoable() && _toolParent != null) {
+			if (actionDetails.isUndoable() && _toolParent != null) {
 				_toolParent.addActionToBuffer(actionDetails);
 			}
 		}
@@ -73,9 +73,9 @@ public class AdvancedZoomInTool extends ZoomInTool {
 
 	@Override
 	public void onMousePressed(final MapMouseEvent ev) {
-		
+
 		if (ev.getButton() != MouseEvent.BUTTON3) {
-			actionDetails = new ViewAction(getMapPane(),"Zoom In");
+			actionDetails = new ViewAction(getMapPane(), "Zoom In");
 			actionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
 			startPosDevice.setLocation(ev.getPoint());
 			startPosWorld.setLocation(ev.getWorldPos());
@@ -102,9 +102,9 @@ public class AdvancedZoomInTool extends ZoomInTool {
 				performZoomOut(ev);
 			}
 			DebriefLiteApp.getInstance().updateProjectionArea();
-			if(actionDetails!=null) {
+			if (actionDetails != null) {
 				actionDetails.setNewProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
-				if(_toolParent!=null && actionDetails.isUndoable()) {
+				if (_toolParent != null && actionDetails.isUndoable()) {
 					_toolParent.addActionToBuffer(actionDetails);
 				}
 			}

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/AdvancedZoomInTool.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/AdvancedZoomInTool.java
@@ -50,7 +50,7 @@ public class AdvancedZoomInTool extends ZoomInTool {
 	@Override
 	public void onMouseClicked(final MapMouseEvent e) {
 		if (e.getButton() != MouseEvent.BUTTON3) {
-			actionDetails = new ViewAction(getMapPane());
+			actionDetails = new ViewAction(getMapPane(),"Zoom In");
 			actionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
 			super.onMouseClicked(e);
 			actionDetails.setNewProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
@@ -75,7 +75,7 @@ public class AdvancedZoomInTool extends ZoomInTool {
 	public void onMousePressed(final MapMouseEvent ev) {
 		
 		if (ev.getButton() != MouseEvent.BUTTON3) {
-			actionDetails = new ViewAction(getMapPane());
+			actionDetails = new ViewAction(getMapPane(),"Zoom In");
 			actionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
 			startPosDevice.setLocation(ev.getPoint());
 			startPosWorld.setLocation(ev.getWorldPos());
@@ -98,6 +98,7 @@ public class AdvancedZoomInTool extends ZoomInTool {
 					super.onMouseReleased(ev);
 				}
 			} else {
+				actionDetails.setActionName("Zoom out");
 				performZoomOut(ev);
 			}
 			DebriefLiteApp.getInstance().updateProjectionArea();

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/AdvancedZoomInTool.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/AdvancedZoomInTool.java
@@ -26,24 +26,37 @@ import org.geotools.swing.event.MapMouseEvent;
 import org.geotools.swing.tool.ZoomInTool;
 import org.locationtech.jts.geom.Coordinate;
 import org.mwc.debrief.lite.DebriefLiteApp;
+import org.mwc.debrief.lite.gui.ViewAction;
+
+import MWC.GUI.ToolParent;
 
 public class AdvancedZoomInTool extends ZoomInTool {
 
 	private final Point startPosDevice;
 	private final Point2D startPosWorld;
 	private boolean dragged;
+	private ToolParent _toolParent;
+	
+	private ViewAction actionDetails;
 
-	public AdvancedZoomInTool() {
+	public AdvancedZoomInTool(ToolParent parent) {
 		super();
 		startPosDevice = new Point();
 		startPosWorld = new DirectPosition2D();
 		dragged = false;
+		_toolParent = parent;
 	}
 
 	@Override
 	public void onMouseClicked(final MapMouseEvent e) {
 		if (e.getButton() != MouseEvent.BUTTON3) {
+			actionDetails = new ViewAction(getMapPane());
+			actionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
 			super.onMouseClicked(e);
+			actionDetails.setNewProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
+			if(actionDetails.isUndoable() && _toolParent != null) {
+				_toolParent.addActionToBuffer(actionDetails);
+			}
 		}
 	}
 
@@ -60,7 +73,10 @@ public class AdvancedZoomInTool extends ZoomInTool {
 
 	@Override
 	public void onMousePressed(final MapMouseEvent ev) {
+		
 		if (ev.getButton() != MouseEvent.BUTTON3) {
+			actionDetails = new ViewAction(getMapPane());
+			actionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
 			startPosDevice.setLocation(ev.getPoint());
 			startPosWorld.setLocation(ev.getWorldPos());
 			super.onMousePressed(ev);
@@ -85,6 +101,12 @@ public class AdvancedZoomInTool extends ZoomInTool {
 				performZoomOut(ev);
 			}
 			DebriefLiteApp.getInstance().updateProjectionArea();
+			if(actionDetails!=null) {
+				actionDetails.setNewProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
+				if(_toolParent!=null && actionDetails.isUndoable()) {
+					_toolParent.addActionToBuffer(actionDetails);
+				}
+			}
 		}
 	}
 
@@ -129,4 +151,5 @@ public class AdvancedZoomInTool extends ZoomInTool {
 			ev.getSource().setDisplayArea(newMapArea);
 		}
 	}
+
 }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/DragElementTool.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/DragElementTool.java
@@ -22,9 +22,11 @@ import org.mwc.debrief.lite.gui.GeoToolMapProjection;
 
 import MWC.GUI.Layer;
 import MWC.GUI.Layers;
+import MWC.GUI.ToolParent;
 import MWC.GUI.Shapes.FindNearest;
 import MWC.GUI.Shapes.HasDraggableComponents;
 import MWC.GUI.Shapes.HasDraggableComponents.ComponentConstruct;
+import MWC.GUI.Tools.Action;
 import MWC.GenericData.WorldLocation;
 import MWC.GenericData.WorldVector;
 
@@ -34,9 +36,18 @@ public class DragElementTool extends GenericDragTool {
 	 * the thing we're currently hovering over
 	 */
 	protected HasDraggableComponents _hoverTarget;
+	
+	private ToolParent _toolParent;
+	private WorldLocation _startLocation;
+	private WorldLocation _lastLocation;
+	private Point _startPoint;
+	private Point _lastPoint;
 
-	public DragElementTool(final Layers layers, final GeoToolMapProjection projection, final JMapPane mapPane) {
+	private WorldVector offset;
+
+	public DragElementTool(final Layers layers, final GeoToolMapProjection projection, final JMapPane mapPane, ToolParent toolParent) {
 		super(layers, projection, mapPane);
+		_toolParent = toolParent;
 	}
 
 	/**
@@ -49,23 +60,53 @@ public class DragElementTool extends GenericDragTool {
 	public void onMouseDragged(final MapMouseEvent ev) {
 		if (panning) {
 			final Point pos = mouseDelta(ev.getPoint());
-
-			if (!pos.equals(panePos)) {
-				final WorldLocation cursorLoc = _projection.toWorld(panePos);
-
-				if (_hoverTarget != null) {
-					final WorldLocation newLocation = new WorldLocation(_projection.toWorld(pos));
-
-					// now work out the vector from the last place plotted to the current
-					// place
-					final WorldVector offset = newLocation.subtract(cursorLoc);
-
-					_hoverTarget.shift(_hoverComponent, offset);
-					_mapPane.repaint();
+			if ((_startPoint != null) && (_hoverTarget != null)) {
+				if(_lastPoint == null) {
+					//the first time
+					_lastLocation = _startLocation;
 				}
-				panePos = pos;
+
+				_lastPoint=new Point(ev.getPoint().x,ev.getPoint().y);
+				if (!pos.equals(panePos)) {
+
+					final WorldLocation cursorLoc = _projection.toWorld(panePos);
+
+					if (_hoverTarget != null) {
+						final WorldLocation newLocation = new WorldLocation(_projection.toWorld(pos));
+
+						// now work out the vector from the last place plotted to the current
+						// place
+						offset = newLocation.subtract(cursorLoc);
+						_lastLocation = newLocation;
+						_hoverTarget.shift(_hoverComponent, offset);
+						_mapPane.repaint();
+					}
+					panePos = pos;
+				}
 			}
 
+		}
+	}
+	
+	
+	@Override
+	public void onMouseReleased(MapMouseEvent ev) {
+		super.onMouseReleased(ev);
+		if(_lastLocation != null && _startLocation != null) {
+			final WorldVector forward = _lastLocation.subtract(_startLocation);
+
+			// put it into our action
+			final DragWholeElementAction dta = new DragWholeElementAction(forward, _hoverTarget, _hoverComponent,
+					layers, _parentLayer);
+
+			if(dta!=null && dta.isUndoable() && _toolParent!=null) {
+				_toolParent.addActionToBuffer(dta);
+			}
+			_startPoint = null;
+			_lastPoint = null;
+			_lastLocation = null;
+			_startLocation = null;
+			_hoverTarget = null;
 		}
 	}
 
@@ -78,7 +119,9 @@ public class DragElementTool extends GenericDragTool {
 	@Override
 	public void onMousePressed(final MapMouseEvent ev) {
 		super.onMousePressed(ev);
-
+		_startPoint = new Point(ev.getPoint().x, ev.getPoint().y);
+		_lastPoint = null;
+		_startLocation = new WorldLocation(_projection.toWorld(new java.awt.Point(ev.getPoint().x, ev.getPoint().y)));
 		if (LiteMapPane.isMapViewportAcceptable(_mapPane) && !panning) {
 			panePos = mouseDelta(ev.getPoint());
 
@@ -123,4 +166,50 @@ public class DragElementTool extends GenericDragTool {
 			}
 		}
 	}
-}
+	
+	private class DragWholeElementAction implements Action{
+		
+		public WorldLocation _component;
+		public WorldVector _offset;
+		public HasDraggableComponents _dragElement;
+		public Layer _parentLayer;
+		private Layers _layers;
+
+		public DragWholeElementAction(WorldVector forward, HasDraggableComponents hoverTarget,
+				WorldLocation hoverComponent, Layers layers, Layer parentLayer) {
+			_dragElement = hoverTarget;
+			_component = hoverComponent;
+			_parentLayer = parentLayer;
+			_layers = layers;
+			_offset = forward;
+		}
+
+		@Override
+		public void execute() {
+			_dragElement.shift(_component, _offset);
+			_mapPane.repaint();
+			
+		}
+
+		@Override
+		public boolean isRedoable() {
+			return true;
+		}
+
+		@Override
+		public boolean isUndoable() {
+			return true;
+		}
+
+		@Override
+		public void undo() {
+			final WorldVector reverseVector = _offset.generateInverse();
+            _dragElement.shift(_component, reverseVector);
+   			_layers.fireModified(_parentLayer);
+		}
+		public String toString() {
+			final String res = "Drag " + _dragElement.getName() + _offset.toString();
+			return res;
+		}
+	}       
+}           

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/DragWholeFeatureElementTool.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/map/DragWholeFeatureElementTool.java
@@ -22,9 +22,11 @@ import org.mwc.debrief.lite.gui.GeoToolMapProjection;
 
 import MWC.GUI.Layer;
 import MWC.GUI.Layers;
+import MWC.GUI.ToolParent;
 import MWC.GUI.Shapes.DraggableItem;
 import MWC.GUI.Shapes.DraggableItem.LocationConstruct;
 import MWC.GUI.Shapes.FindNearest;
+import MWC.GUI.Tools.Action;
 import MWC.GenericData.WorldLocation;
 import MWC.GenericData.WorldVector;
 
@@ -33,11 +35,17 @@ public class DragWholeFeatureElementTool extends GenericDragTool {
 	/**
 	 * the thing we're currently hovering over
 	 */
-	protected DraggableItem _hoverTarget;
+	
+	private ToolParent _toolParent;
+	private DraggableItem _hoverTarget;
+	private WorldLocation _lastLocation;
+	private WorldLocation _startLocation;
+	private Point _startPoint,_lastPoint;
 
 	public DragWholeFeatureElementTool(final Layers layers, final GeoToolMapProjection projection,
-			final JMapPane mapPane) {
+			final JMapPane mapPane,ToolParent parent) {
 		super(layers, projection, mapPane);
+		_toolParent = parent;
 	}
 
 	/**
@@ -49,23 +57,52 @@ public class DragWholeFeatureElementTool extends GenericDragTool {
 	@Override
 	public void onMouseDragged(final MapMouseEvent ev) {
 		if (panning) {
-			final Point pos = mouseDelta(ev.getPoint());
-
-			if (!pos.equals(panePos)) {
-				final WorldLocation cursorLoc = _projection.toWorld(panePos);
-
-				if (_hoverTarget != null) {
-					final WorldLocation newLocation = new WorldLocation(_projection.toWorld(pos));
-
-					// now work out the vector from the last place plotted to the current
-					// place
-					final WorldVector offset = newLocation.subtract(cursorLoc);
-
-					_hoverTarget.shift(offset);
-					_mapPane.repaint();
+			if ((_startPoint != null) && (_hoverTarget != null)) {
+				if(_lastPoint == null) {
+					//the first time
+					_lastLocation = _startLocation;
 				}
-				panePos = pos;
+
+				_lastPoint=new Point(ev.getPoint().x,ev.getPoint().y);
+				final Point pos = mouseDelta(ev.getPoint());
+
+				if (!pos.equals(panePos)) {
+					final WorldLocation cursorLoc = _projection.toWorld(panePos);
+
+					if (_hoverTarget != null) {
+						final WorldLocation newLocation = new WorldLocation(_projection.toWorld(pos));
+
+						// now work out the vector from the last place plotted to the current
+						// place
+						final WorldVector offset = newLocation.subtract(cursorLoc);
+						_lastLocation = newLocation;
+						_hoverTarget.shift(offset);
+						_mapPane.repaint();
+					}
+					panePos = pos;
+				}
 			}
+		}
+	}
+
+	@Override
+	public void onMouseReleased(MapMouseEvent ev) {
+		super.onMouseReleased(ev);
+		if(_lastLocation != null && _startLocation != null) {
+			final WorldVector forward = _lastLocation.subtract(_startLocation);
+
+			// put it into our action
+			final DragWholeFeatureAction dta = new DragWholeFeatureAction(forward, _hoverTarget, 
+					layers, _parentLayer);
+
+			if(dta!=null && dta.isUndoable() && _toolParent!=null) {
+				_toolParent.addActionToBuffer(dta);
+			}
+			_startPoint = null;
+			_lastPoint = null;
+			_lastLocation = null;
+			_startLocation = null;
+			_hoverTarget = null;
 		}
 	}
 
@@ -78,7 +115,9 @@ public class DragWholeFeatureElementTool extends GenericDragTool {
 	@Override
 	public void onMousePressed(final MapMouseEvent ev) {
 		super.onMousePressed(ev);
-
+		_startPoint = new Point(ev.getPoint().x, ev.getPoint().y);
+		_lastPoint = null;
+		_startLocation = new WorldLocation(_projection.toWorld(new java.awt.Point(ev.getPoint().x, ev.getPoint().y)));
 		if (LiteMapPane.isMapViewportAcceptable(_mapPane) && !panning) {
 			panePos = mouseDelta(ev.getPoint());
 
@@ -121,5 +160,48 @@ public class DragWholeFeatureElementTool extends GenericDragTool {
 				}
 			}
 		}
+	}
+	
+	private class DragWholeFeatureAction implements Action{
+		DraggableItem _itemToDrag;
+		WorldVector _theOffset;
+		Layers _layers;
+		Layer _parentLayer;
+		public DragWholeFeatureAction(final WorldVector theOffset, final DraggableItem theTrack, final Layers theLayers,
+										final Layer parentLayer) {
+			_theOffset = theOffset;
+			_itemToDrag = theTrack;
+			_layers = theLayers;
+			_parentLayer = parentLayer;
+		}
+		
+		@Override
+		public void execute() {
+			_itemToDrag.shift(_theOffset);
+			_mapPane.repaint();			
+		}
+
+		@Override
+		public boolean isRedoable() {
+			return true;
+		}
+
+		@Override
+		public boolean isUndoable() {
+			return true;
+		}
+
+		@Override
+		public void undo() {
+			final WorldVector reverseVector = _theOffset.generateInverse();
+			_itemToDrag.shift(reverseVector);
+			_layers.fireModified(_parentLayer);			
+		}
+		
+		public String toString() {
+			final String res = "Drag " + _itemToDrag.getName() + _theOffset.toString();
+			return res;
+		}
+		
 	}
 }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/menu/DebriefRibbon.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/menu/DebriefRibbon.java
@@ -45,7 +45,7 @@ public class DebriefRibbon {
 		DebriefRibbonLite.addLiteTab(ribbon, session, resetAction, exitAction, collapseAction, path);
 		DebriefRibbonFile.addFileTab(ribbon, geoMapRenderer, session, resetAction);
 		DebriefRibbonView.addViewTab(ribbon, geoMapRenderer, layers, statusBar, projection, transform, alphaListener,
-				alpha);
+				alpha,parent);
 		DebriefRibbonInsert.addInsertTab(ribbon, geoMapRenderer, layers, null, parent);
 		DebriefRibbonTimeController.addTimeControllerTab(ribbon, geoMapRenderer, stepControl, timeManager, operations,
 				layers, session.getUndoBuffer(), normalPainter, snailPainter, refresh);

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/menu/DebriefRibbonView.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/menu/DebriefRibbonView.java
@@ -189,11 +189,11 @@ public class DebriefRibbonView {
 		viewBand.addRibbonCommand(rangeBearingCommand,PresentationPriority.TOP);
 
 		final DragElementAction dragWholeFeatureInAction = new DragElementAction(mapPane,
-				new DragWholeFeatureElementTool(layers, projection, mapPane));
+				new DragWholeFeatureElementTool(layers, projection, mapPane,toolParent));
 		MenuUtils.addCommandToggleButton("Drag Whole Feature", "icons/24/select_feature.png", dragWholeFeatureInAction,
 				viewBand, PresentationPriority.TOP, true, mouseModeGroup, false);
 		final DragElementAction dragElementInAction = new DragElementAction(mapPane,
-				new DragElementTool(layers, projection, mapPane));
+				new DragElementTool(layers, projection, mapPane,toolParent));
 		MenuUtils.addCommandToggleButton("Drag Element", "icons/24/select_component.png", dragElementInAction, viewBand,
 				PresentationPriority.TOP, true, mouseModeGroup, false);
 

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/menu/DebriefRibbonView.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/menu/DebriefRibbonView.java
@@ -65,6 +65,7 @@ import org.pushingpixels.flamingo.api.ribbon.synapse.projection.ComponentProject
 
 import MWC.Algorithms.PlainProjection;
 import MWC.GUI.Layers;
+import MWC.GUI.ToolParent;
 import MWC.GenericData.WorldDistance;
 
 public class DebriefRibbonView {
@@ -94,9 +95,9 @@ public class DebriefRibbonView {
 
 	protected static void addViewTab(final JRibbon ribbon, final GeoToolMapRenderer geoMapRenderer, final Layers layers,
 			final JLabel statusBar, final GeoToolMapProjection projection, final MathTransform transform,
-			final ChangeListener alphaListener, final float alpha) {
-		final JRibbonBand mouseMode = createMouseModes(geoMapRenderer, statusBar, layers, projection, transform);
-		final JRibbonBand mapCommands = createMapCommands(geoMapRenderer, layers, projection);
+			final ChangeListener alphaListener, final float alpha,final ToolParent toolParent) {
+		final JRibbonBand mouseMode = createMouseModes(geoMapRenderer, statusBar, layers, projection, transform,toolParent);
+		final JRibbonBand mapCommands = createMapCommands(geoMapRenderer, layers, projection,toolParent);
 
 		// and the slider
 		final JRibbonBand layersMenu = new JRibbonBand("Background", null);
@@ -116,13 +117,14 @@ public class DebriefRibbonView {
 	}
 
 	private static JRibbonBand createMapCommands(final GeoToolMapRenderer geoMapRenderer, final Layers layers,
-			final PlainProjection projection) {
+			final PlainProjection projection,ToolParent parent) {
 		final JMapPane mapPane = (JMapPane) geoMapRenderer.getMap();
 		final JRibbonBand commandBand = new JRibbonBand("Map commands", null);
 		commandBand.startGroup();
-		MenuUtils.addCommand("Zoom Out", "icons/24/zoomout.png", new ZoomOut(mapPane), commandBand,
+		ZoomOut zoomoutAction = new ZoomOut(mapPane,parent);
+		MenuUtils.addCommand("Zoom Out", "icons/24/zoomout.png", zoomoutAction, commandBand,
 				PresentationPriority.TOP, "Zoom out to reduce size of plot");
-		final FitToWindow doFit = new FitToWindow(layers, mapPane, projection);
+		final FitToWindow doFit = new FitToWindow(layers, mapPane, projection,parent);
 		MenuUtils.addCommand("Fit to Window", "icons/24/fit_to_win.png", doFit, commandBand, null,
 				"Fit the plot to available space");
 		commandBand.setResizePolicies(MenuUtils.getStandardRestrictivePolicies(commandBand));
@@ -130,7 +132,7 @@ public class DebriefRibbonView {
 	}
 
 	private static JRibbonBand createMouseModes(final GeoToolMapRenderer geoMapRenderer, final JLabel statusBar,
-			final Layers layers, final GeoToolMapProjection projection, final MathTransform transform) {
+			final Layers layers, final GeoToolMapProjection projection, final MathTransform transform,final ToolParent toolParent) {
 		final JRibbonBand viewBand = new JRibbonBand("Mouse mode", null);
 		final JMapPane mapPane = (JMapPane) geoMapRenderer.getMap();
 
@@ -138,9 +140,11 @@ public class DebriefRibbonView {
 		final CommandToggleGroupModel mouseModeGroup = new CommandToggleGroupModel();
 
 		viewBand.startGroup();
-		MenuUtils.addCommandToggleButton("Pan", "icons/24/hand.png", new PanCommandAction(mapPane), viewBand,
+		PanCommandAction panAction = new PanCommandAction(mapPane,toolParent);
+		MenuUtils.addCommandToggleButton("Pan", "icons/24/hand.png", panAction, viewBand,
 				PresentationPriority.TOP, true, mouseModeGroup, false);
-		zoomInAction = new AdvancedZoomInAction(mapPane);
+		
+		zoomInAction = new AdvancedZoomInAction(mapPane,toolParent);
 		zoominButton = MenuUtils.addCommandToggleButton("Zoom In", "icons/24/zoomin.png", zoomInAction, viewBand,
 				PresentationPriority.TOP, true, mouseModeGroup, true);
 		final RangeBearingAction rangeAction = new RangeBearingAction(mapPane, false, statusBar, transform);

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/view/actions/DebriefPanTool.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/view/actions/DebriefPanTool.java
@@ -49,7 +49,7 @@ public class DebriefPanTool extends PanTool{
 	@Override
 	public void onMousePressed(MapMouseEvent ev) {
 		super.onMousePressed(ev);
-		actionDetails = new ViewAction(getMapPane());
+		actionDetails = new ViewAction(getMapPane(),"Pan");
 		actionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
 		System.out.println("Last projectionArea:"+actionDetails.getNewProjectionArea());
 	}

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/view/actions/DebriefPanTool.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/view/actions/DebriefPanTool.java
@@ -10,7 +10,7 @@
  *
  *    This library is distributed in the hope that it will be useful,
  *    but WITHOUT ANY WARRANTY; without even the implied warranty of
- *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 package org.mwc.debrief.lite.view.actions;
 
@@ -25,34 +25,34 @@ import MWC.GUI.ToolParent;
  * @author Ayesha
  *
  */
-public class DebriefPanTool extends PanTool{
-	
-	private ToolParent _toolParent;
+public class DebriefPanTool extends PanTool {
+
+	private final ToolParent _toolParent;
 	int curIndex;
 	private ViewAction actionDetails;
-	DebriefPanTool(ToolParent parent){
+
+	DebriefPanTool(final ToolParent parent) {
 		_toolParent = parent;
 	}
-	
+
+	@Override
+	public void onMousePressed(final MapMouseEvent ev) {
+		super.onMousePressed(ev);
+		actionDetails = new ViewAction(getMapPane(), "Pan");
+		actionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
+		System.out.println("Last projectionArea:" + actionDetails.getNewProjectionArea());
+	}
+
 	@Override
 	public void onMouseReleased(final MapMouseEvent ev) {
 		super.onMouseReleased(ev);
 		DebriefLiteApp.getInstance().updateProjectionArea();
-		
+
 		actionDetails.setNewProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
-		System.out.println("new projectionArea:"+actionDetails.getLastProjectionArea());
-		if(_toolParent!=null){
+		System.out.println("new projectionArea:" + actionDetails.getLastProjectionArea());
+		if (_toolParent != null) {
 			_toolParent.addActionToBuffer(actionDetails);
 		}
 	}
-	
-	@Override
-	public void onMousePressed(MapMouseEvent ev) {
-		super.onMousePressed(ev);
-		actionDetails = new ViewAction(getMapPane(),"Pan");
-		actionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
-		System.out.println("Last projectionArea:"+actionDetails.getNewProjectionArea());
-	}
 
-	
 }

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/view/actions/DebriefPanTool.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/view/actions/DebriefPanTool.java
@@ -1,0 +1,58 @@
+/*
+ *    Debrief - the Open Source Maritime Analysis Application
+ *    http://debrief.info
+ *
+ *    (C) 2000-2016, Deep Blue C Technology Ltd
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the Eclipse Public License v1.0
+ *    (http://www.eclipse.org/legal/epl-v10.html)
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ */
+package org.mwc.debrief.lite.view.actions;
+
+import org.geotools.swing.event.MapMouseEvent;
+import org.geotools.swing.tool.PanTool;
+import org.mwc.debrief.lite.DebriefLiteApp;
+import org.mwc.debrief.lite.gui.ViewAction;
+
+import MWC.GUI.ToolParent;
+
+/**
+ * @author Ayesha
+ *
+ */
+public class DebriefPanTool extends PanTool{
+	
+	private ToolParent _toolParent;
+	int curIndex;
+	private ViewAction actionDetails;
+	DebriefPanTool(ToolParent parent){
+		_toolParent = parent;
+	}
+	
+	@Override
+	public void onMouseReleased(final MapMouseEvent ev) {
+		super.onMouseReleased(ev);
+		DebriefLiteApp.getInstance().updateProjectionArea();
+		
+		actionDetails.setNewProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
+		System.out.println("new projectionArea:"+actionDetails.getLastProjectionArea());
+		if(_toolParent!=null){
+			_toolParent.addActionToBuffer(actionDetails);
+		}
+	}
+	
+	@Override
+	public void onMousePressed(MapMouseEvent ev) {
+		super.onMousePressed(ev);
+		actionDetails = new ViewAction(getMapPane());
+		actionDetails.setLastProjectionArea(DebriefLiteApp.getInstance().getProjectionArea());
+		System.out.println("Last projectionArea:"+actionDetails.getNewProjectionArea());
+	}
+
+	
+}

--- a/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/view/actions/PanCommandAction.java
+++ b/org.mwc.debrief.lite/src/main/java/org/mwc/debrief/lite/view/actions/PanCommandAction.java
@@ -19,11 +19,11 @@ import java.awt.event.ActionEvent;
 
 import org.geotools.swing.MapPane;
 import org.geotools.swing.action.PanAction;
-import org.geotools.swing.event.MapMouseEvent;
-import org.geotools.swing.tool.PanTool;
-import org.mwc.debrief.lite.DebriefLiteApp;
 import org.pushingpixels.flamingo.api.common.CommandAction;
 import org.pushingpixels.flamingo.api.common.CommandActionEvent;
+
+import MWC.GUI.ToolParent;
+import MWC.GUI.Tools.Action;
 
 /**
  * @author Ayesha
@@ -35,27 +35,28 @@ public class PanCommandAction extends PanAction implements CommandAction {
 	 *
 	 */
 	private static final long serialVersionUID = 1L;
+	
+	private ToolParent _toolParent;
+	private DebriefPanTool _panTool;
 
-	public PanCommandAction(final MapPane mapPane) {
+	public PanCommandAction(final MapPane mapPane,ToolParent parent) {
 		super(mapPane);
-		// TODO Auto-generated constructor stub
+		_toolParent = parent;
+		_panTool = new DebriefPanTool(_toolParent);
 	}
 
 	@Override
 	public void actionPerformed(final ActionEvent ev) {
-		getMapPane().setCursorTool(new PanTool() {
-
-			@Override
-			public void onMouseReleased(final MapMouseEvent ev) {
-				super.onMouseReleased(ev);
-				DebriefLiteApp.getInstance().updateProjectionArea();
-			}
-
-		});
+		getMapPane().setCursorTool(_panTool);
 	}
 
 	@Override
 	public void commandActivated(final CommandActionEvent e) {
 		actionPerformed(e);
+	}
+
+	@Override
+	public final String toString() {
+		return _panTool.toString();
 	}
 }


### PR DESCRIPTION
Fixes #4175 

The undo and redo for the all the view actions pan,zoom in,zoom out, and fit to window are done using a single method
Remember the previous projectionarea and undo will set to the last projection area. When command is executed the new projection area is remembered and redo will set the new projection area.
