### PR TITLE
fixed by using the dash array settings in the stroke

### DIFF
--- a/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/CanvasAdaptor.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/CanvasAdaptor.java
@@ -331,7 +331,7 @@ public class CanvasAdaptor implements MWC.GUI.CanvasType {
 	@Override
 	public void setLineStyle(final int style) {
 		final BasicStroke stk = MWC.GUI.Canvas.Swing.SwingCanvas.getStrokeFor(style);
-		final BasicStroke stk2 = new BasicStroke(getLineWidth(), stk.getEndCap(), stk.getLineJoin());
+		final BasicStroke stk2 = new BasicStroke(getLineWidth(), stk.getEndCap(), stk.getLineJoin(),stk.getMiterLimit(),stk.getDashArray(),stk.getDashPhase());
 		final Graphics2D g2 = (Graphics2D) _dest;
 		g2.setStroke(stk2);
 	}

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/Swing/SwingCanvas.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/Swing/SwingCanvas.java
@@ -350,7 +350,7 @@ public class SwingCanvas extends javax.swing.JComponent implements CanvasType, E
 			_myLineStyles.put(MWC.GUI.CanvasType.DOT_DASH, new BasicStroke(1,
 					BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1, new float[] { 4, 4, 12, 4 }, 0));
 			_myLineStyles.put(MWC.GUI.CanvasType.SHORT_DASHES, new BasicStroke(1,
-					BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1, new float[] { 6, 6 }, 0));
+					BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1, new float[] { 4,4,4,4,12,4 }, 0));
 			_myLineStyles.put(MWC.GUI.CanvasType.LONG_DASHES, new BasicStroke(1,
 					BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1, new float[] { 12, 6 }, 0));
 			_myLineStyles.put(MWC.GUI.CanvasType.UNCONNECTED, new BasicStroke(1));

--- a/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/Swing/SwingCanvas.java
+++ b/org.mwc.cmap.legacy/src/MWC/GUI/Canvas/Swing/SwingCanvas.java
@@ -343,20 +343,20 @@ public class SwingCanvas extends javax.swing.JComponent implements CanvasType, E
 	static synchronized public java.awt.BasicStroke getStrokeFor(final int style) {
 		if (_myLineStyles == null) {
 			_myLineStyles = new java.util.HashMap<Integer, BasicStroke>(5);
-			_myLineStyles.put(new Integer(MWC.GUI.CanvasType.SOLID), new java.awt.BasicStroke(1,
-					java.awt.BasicStroke.CAP_BUTT, java.awt.BasicStroke.JOIN_MITER, 1, new float[] { 5, 0 }, 0));
-			_myLineStyles.put(new Integer(MWC.GUI.CanvasType.DOTTED), new java.awt.BasicStroke(1,
-					java.awt.BasicStroke.CAP_BUTT, java.awt.BasicStroke.JOIN_MITER, 1, new float[] { 2, 6 }, 0));
-			_myLineStyles.put(new Integer(MWC.GUI.CanvasType.DOT_DASH), new java.awt.BasicStroke(1,
-					java.awt.BasicStroke.CAP_BUTT, java.awt.BasicStroke.JOIN_MITER, 1, new float[] { 4, 4, 12, 4 }, 0));
-			_myLineStyles.put(new Integer(MWC.GUI.CanvasType.SHORT_DASHES), new java.awt.BasicStroke(1,
-					java.awt.BasicStroke.CAP_BUTT, java.awt.BasicStroke.JOIN_MITER, 1, new float[] { 6, 6 }, 0));
-			_myLineStyles.put(new Integer(MWC.GUI.CanvasType.LONG_DASHES), new java.awt.BasicStroke(1,
-					java.awt.BasicStroke.CAP_BUTT, java.awt.BasicStroke.JOIN_MITER, 1, new float[] { 12, 6 }, 0));
-			_myLineStyles.put(new Integer(MWC.GUI.CanvasType.UNCONNECTED), new java.awt.BasicStroke(1));
+			_myLineStyles.put(MWC.GUI.CanvasType.SOLID, new BasicStroke(1,
+					BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1, new float[] { 5, 0 }, 0));
+			_myLineStyles.put(MWC.GUI.CanvasType.DOTTED, new BasicStroke(1,
+					BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1, new float[] { 2, 6 }, 0));
+			_myLineStyles.put(MWC.GUI.CanvasType.DOT_DASH, new BasicStroke(1,
+					BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1, new float[] { 4, 4, 12, 4 }, 0));
+			_myLineStyles.put(MWC.GUI.CanvasType.SHORT_DASHES, new BasicStroke(1,
+					BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1, new float[] { 6, 6 }, 0));
+			_myLineStyles.put(MWC.GUI.CanvasType.LONG_DASHES, new BasicStroke(1,
+					BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1, new float[] { 12, 6 }, 0));
+			_myLineStyles.put(MWC.GUI.CanvasType.UNCONNECTED, new BasicStroke(1));
 		}
 
-		return _myLineStyles.get(new Integer(style));
+		return _myLineStyles.get(style);
 	}
 
 	private final Object LOCK = new Object();


### PR DESCRIPTION
Fixes #4360 

The line style settings are being updated now.  The dash[] and dash phase settings were not being passed on while creating the BasicStroke object.