### PR TITLE
Use correct pepys ini file param names in Debrief

### DIFF
--- a/org.mwc.debrief.pepys/sqlite.ini
+++ b/org.mwc.debrief.pepys/sqlite.ini
@@ -1,4 +1,4 @@
 [database]
-db_name = org.mwc.cmap.combined.feature/root_installs/sample_data/other_formats/pepys.sqlite
-db_type = sqlite
+database_name = org.mwc.cmap.combined.feature/root_installs/sample_data/other_formats/pepys.sqlite
+database_type = sqlite
 # Comment

--- a/org.mwc.debrief.pepys/src/main/java/org/mwc/debrief/pepys/controller/PepysImportController.java
+++ b/org.mwc.debrief.pepys/src/main/java/org/mwc/debrief/pepys/controller/PepysImportController.java
@@ -574,9 +574,9 @@ public class PepysImportController
           messageToUser.append("\n");
           messageToUser.append("Configuration in use: ");
           messageToUser.append(configurationToUse);
-          final HashMap<String, String> databaseCategory = model
-              .getDatabaseConnection().getDatabaseConfiguration().getCategory(
-                  DatabaseConnection.CONFIGURATION_TAG);
+          final DatabaseConnection conn = model.getDatabaseConnection();
+          final DatabaseConfiguration config = conn.getDatabaseConfiguration();
+          final HashMap<String, String> databaseCategory = config.getCategory(DatabaseConnection.CONFIGURATION_TAG);
           if (databaseCategory != null)
           {
             messageToUser.append("\n\n");

--- a/org.mwc.debrief.pepys/src/main/java/org/mwc/debrief/pepys/model/db/DatabaseConnection.java
+++ b/org.mwc.debrief.pepys/src/main/java/org/mwc/debrief/pepys/model/db/DatabaseConnection.java
@@ -76,9 +76,9 @@ public abstract class DatabaseConnection {
 
 	public static final String CONFIGURATION_TAG = "database";
 
-	public static final String CONFIGURATION_DATABASE_TYPE = "db_type";
+	public static final String CONFIGURATION_DATABASE_TYPE = "database_type";
 
-	public static final String CONFIGURATION_DB_NAME = "db_name";
+	public static final String CONFIGURATION_DB_NAME = "database_name";
 
 	public static final String POSTGRES = "postgres";
 

--- a/org.mwc.debrief.pepys/src/main/java/org/mwc/debrief/pepys/model/db/PostgresDatabaseConnection.java
+++ b/org.mwc.debrief.pepys/src/main/java/org/mwc/debrief/pepys/model/db/PostgresDatabaseConnection.java
@@ -40,10 +40,10 @@ import MWC.GenericData.WorldLocation;
 
 public class PostgresDatabaseConnection extends DatabaseConnection {
 
-	private static final String DB_PORT_TAG = "db_port";
-	private static final String DB_HOST_TAG = "db_host";
-	private static final String DB_PASSWORD_TAG = "db_password";
-	private static final String DB_USERNAME_TAG = "db_username";
+	private static final String DB_PORT_TAG = "database_port";
+	private static final String DB_HOST_TAG = "database_host";
+	private static final String DB_PASSWORD_TAG = "database_password";
+	private static final String DB_USERNAME_TAG = "database_username";
 	private static final String HOST_HEADER = "jdbc:postgresql://";
 
 	/**

--- a/org.mwc.debrief.pepys/src/main/java/org/mwc/debrief/pepys/model/db/config/ConfigurationReader.java
+++ b/org.mwc.debrief.pepys/src/main/java/org/mwc/debrief/pepys/model/db/config/ConfigurationReader.java
@@ -15,8 +15,8 @@ public class ConfigurationReader {
 	public static class ConfigurationReaderTest extends TestCase {
 
 		public void testConfigurationRead() {
-			final String testConfiguration = "[database]\n" + "db_username = abcdef\n" + "db_password = abcdef\n"
-					+ "db_host = localhost\n" + "db_port = 5432\n" + "db_name = pepys2\n" + "[archive]\n"
+			final String testConfiguration = "[database]\n" + "database_username = abcdef\n" + "database_password = abcdef\n"
+					+ "database_host = localhost\n" + "database_port = 5432\n" + "database_name = pepys2\n" + "[archive]\n"
 					+ "user = abcdef\n" + "password = abcdef";
 			final InputStream stream = new ByteArrayInputStream(testConfiguration.getBytes());
 			final DatabaseConfiguration databaseConfigurationTest = new DatabaseConfiguration();
@@ -29,10 +29,10 @@ public class ConfigurationReader {
 			assertTrue("databaseCategory - size", databaseCategory.size() == 5);
 			assertTrue("archiveCategory - size", archiveCategory.size() == 2);
 
-			assertTrue("DBUsername", databaseCategory.get("db_username").equals("abcdef"));
-			assertTrue("DBPassword", databaseCategory.get("db_password").equals("abcdef"));
-			assertTrue("DBHost", databaseCategory.get("db_host").equals("localhost"));
-			assertTrue("DBPort", databaseCategory.get("db_port").equals("5432"));
+			assertTrue("DBUsername", databaseCategory.get("database_username").equals("abcdef"));
+			assertTrue("DBPassword", databaseCategory.get("database_password").equals("abcdef"));
+			assertTrue("DBHost", databaseCategory.get("database_host").equals("localhost"));
+			assertTrue("DBPort", databaseCategory.get("database_port").equals("5432"));
 			assertTrue("archiveCategory - User", archiveCategory.get("user").equals("abcdef"));
 
 		}


### PR DESCRIPTION
Fixes issue in debrief/pepys-import#1052

The names of the parameters in the ini file had changed.  The new names needed to be used in Debrief.