### PR TITLE
increment product number

### DIFF
--- a/org.mwc.debrief.core/about.mappings
+++ b/org.mwc.debrief.core/about.mappings
@@ -2,6 +2,6 @@
 # contains fill-ins for about.properties
 # java.io.Properties file (ISO 8859-1 with "\" escapes)
 # This file does not need to be translated.
-0=3.1.38
+0=3.1.40
 1=20240613
 2=2024-06-13

--- a/org.mwc.debrief.product/debriefng.product
+++ b/org.mwc.debrief.product/debriefng.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="DebriefNG" uid="DebriefNG" id="org.mwc.debrief.core.Debrief" application="org.eclipse.ui.ide.workbench" version="3.1.38" useFeatures="true" includeLaunchers="true">
+<product name="DebriefNG" uid="DebriefNG" id="org.mwc.debrief.core.Debrief" application="org.eclipse.ui.ide.workbench" version="3.1.40" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <image path="icons/DebriefNGlogoSmall.png"/>

--- a/org.mwc.debrief.product/pom.xml
+++ b/org.mwc.debrief.product/pom.xml
@@ -95,5 +95,5 @@
 			</plugin>
 		</plugins>
 	</build>
-<version>3.1.38</version>
+<version>3.1.40</version>
 </project>


### PR DESCRIPTION
We'd performed some manual releases, where the `tag` was updated, but not the product sources.

This PR puts the product version in line with the git release tags