### PR TITLE
5196 do not delete last cut

### DIFF
--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/operations/RightClickCutCopyAdaptor.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/operations/RightClickCutCopyAdaptor.java
@@ -48,7 +48,6 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 import org.mwc.cmap.core.CorePlugin;
 import org.mwc.cmap.core.ui_support.OutlineNameSorter;
-import org.mwc.debrief.core.editors.MessageBox;
 
 import Debrief.Wrappers.FixWrapper;
 import Debrief.Wrappers.SensorContactWrapper;

--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/operations/RightClickCutCopyAdaptor.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/operations/RightClickCutCopyAdaptor.java
@@ -48,6 +48,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 import org.mwc.cmap.core.CorePlugin;
 import org.mwc.cmap.core.ui_support.OutlineNameSorter;
+import org.mwc.debrief.core.editors.MessageBox;
 
 import Debrief.Wrappers.FixWrapper;
 import Debrief.Wrappers.SensorContactWrapper;
@@ -55,6 +56,7 @@ import Debrief.Wrappers.SensorWrapper;
 import Debrief.Wrappers.TMAContactWrapper;
 import Debrief.Wrappers.TMAWrapper;
 import Debrief.Wrappers.TrackWrapper;
+import Debrief.Wrappers.Track.CoreTMASegment;
 import Debrief.Wrappers.Track.DynamicInfillSegment;
 import MWC.GUI.Editable;
 import MWC.GUI.HasEditables;
@@ -985,6 +987,34 @@ public class RightClickCutCopyAdaptor {
 	// /////////////////////////////////
 	// member functions
 	// ////////////////////////////////
+	static boolean isTryingToDeleteAllLegItems(final Editable[] selection, final HasEditables[] parents) {
+		boolean sameParent = true;
+		HasEditables firstParent = parents[0];
+		for (int i = 1; i < parents.length; i++) {
+			if (parents[i] != firstParent) {
+				sameParent = false;
+				break;
+			}
+		}
+
+		final HasEditables[] firstArray = {firstParent};
+		final HasEditables[] safeParents = (sameParent) ? firstArray : parents;		
+		
+		// if it's a single parent, check we're not trying to delete
+		// all children
+		if(safeParents.length == 1) {
+			HasEditables parent = safeParents[0];
+			if (parent instanceof CoreTMASegment) {
+				CoreTMASegment segment = (CoreTMASegment) parent;
+				if (segment.size() == selection.length ) {
+					System.err.println("Cannot delete all items from TMA Leg");
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+	
 	static public void getDropdownListFor(final IMenuManager manager, final Editable[] editables,
 			final Layer[] updateLayers, final HasEditables[] parentLayers, final Layers theLayers,
 			final Clipboard _clipboard) {
@@ -1025,7 +1055,11 @@ public class RightClickCutCopyAdaptor {
 				manager.add(copier);
 			}
 
-			manager.add(deleter);
+			final boolean skipIt = isTryingToDeleteAllLegItems(editables, parentLayers);	
+			
+			if (!skipIt) {
+				manager.add(deleter);				
+			}
 		}
 
 	}

--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/operations/RightClickCutCopyAdaptor.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/operations/RightClickCutCopyAdaptor.java
@@ -1014,34 +1014,6 @@ public class RightClickCutCopyAdaptor {
 		return false;
 	}
 	
-	static boolean isTryingToDeleteAllLegItems(final Editable[] selection, final HasEditables[] parents) {
-		boolean sameParent = true;
-		HasEditables firstParent = parents[0];
-		for (int i = 1; i < parents.length; i++) {
-			if (parents[i] != firstParent) {
-				sameParent = false;
-				break;
-			}
-		}
-
-		final HasEditables[] firstArray = {firstParent};
-		final HasEditables[] safeParents = (sameParent) ? firstArray : parents;		
-		
-		// if it's a single parent, check we're not trying to delete
-		// all children
-		if(safeParents.length == 1) {
-			HasEditables parent = safeParents[0];
-			if (parent instanceof CoreTMASegment) {
-				CoreTMASegment segment = (CoreTMASegment) parent;
-				if (segment.size() == selection.length ) {
-					System.err.println("Cannot delete all items from TMA Leg");
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-	
 	static public void getDropdownListFor(final IMenuManager manager, final Editable[] editables,
 			final Layer[] updateLayers, final HasEditables[] parentLayers, final Layers theLayers,
 			final Clipboard _clipboard) {

--- a/org.mwc.cmap.core/src/org/mwc/cmap/core/operations/RightClickCutCopyAdaptor.java
+++ b/org.mwc.cmap.core/src/org/mwc/cmap/core/operations/RightClickCutCopyAdaptor.java
@@ -1015,6 +1015,34 @@ public class RightClickCutCopyAdaptor {
 		return false;
 	}
 	
+	static boolean isTryingToDeleteAllLegItems(final Editable[] selection, final HasEditables[] parents) {
+		boolean sameParent = true;
+		HasEditables firstParent = parents[0];
+		for (int i = 1; i < parents.length; i++) {
+			if (parents[i] != firstParent) {
+				sameParent = false;
+				break;
+			}
+		}
+
+		final HasEditables[] firstArray = {firstParent};
+		final HasEditables[] safeParents = (sameParent) ? firstArray : parents;		
+		
+		// if it's a single parent, check we're not trying to delete
+		// all children
+		if(safeParents.length == 1) {
+			HasEditables parent = safeParents[0];
+			if (parent instanceof CoreTMASegment) {
+				CoreTMASegment segment = (CoreTMASegment) parent;
+				if (segment.size() == selection.length ) {
+					System.err.println("Cannot delete all items from TMA Leg");
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+	
 	static public void getDropdownListFor(final IMenuManager manager, final Editable[] editables,
 			final Layer[] updateLayers, final HasEditables[] parentLayers, final Layers theLayers,
 			final Clipboard _clipboard) {
@@ -1045,17 +1073,19 @@ public class RightClickCutCopyAdaptor {
 			deleter = new DeleteItem(editables, parentLayers, theLayers, updateLayers);
 
 			// create the menu items
+			final boolean skipIt = isTryingToDeleteAllLegItems(editables, parentLayers);	
 
 			// add to the menu
 			manager.add(new Separator());
-			manager.add(cutter);
+			
+			if (!skipIt) {
+				manager.add(cutter);
+			}
 
 			// try the copier
 			if (copier != null) {
 				manager.add(copier);
 			}
-
-			final boolean skipIt = isTryingToDeleteAllLegItems(editables, parentLayers);	
 			
 			if (!skipIt) {
 				manager.add(deleter);				

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateInfillSegment.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateInfillSegment.java
@@ -1034,7 +1034,9 @@ public class GenerateInfillSegment implements RightClickContextItemGenerator {
 					boolean canDo = true;
 					for (int i = 0; i < subjects.length; i++) {
 						final Editable editable = subjects[i];
-						if (!(editable instanceof TrackSegment)) {
+						if (editable instanceof TrackSegment) {
+							canDo = !((TrackSegment)editable).isEmpty();
+						} else {
 							canDo = false;
 						}
 					}

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/SelectAllChildren.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/SelectAllChildren.java
@@ -300,7 +300,11 @@ public class SelectAllChildren implements RightClickContextItemGenerator {
 		TimePeriod res;
 		if (selected instanceof TrackSegment) {
 			final TrackSegment track = (TrackSegment) selected;
-			res = new TimePeriod.BaseTimePeriod(track.startDTG(), track.endDTG());
+			if (track.isEmpty()) {
+				res = null;
+			} else {
+				res = new TimePeriod.BaseTimePeriod(track.startDTG(), track.endDTG());
+			}
 		} else {
 			res = null;
 		}

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/drag/RotateDragMode.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/drag/RotateDragMode.java
@@ -126,7 +126,7 @@ public class RotateDragMode extends DragMode {
 			while (numer.hasMoreElements()) {
 				final TrackSegment seg = (TrackSegment) numer.nextElement();
 
-				if (seg.getVisible() && isAcceptable(seg)) {
+				if (seg.getVisible() && !seg.isEmpty() && isAcceptable(seg)) {
 					final FixWrapper first = (FixWrapper) seg.first();
 					final FixWrapper last = (FixWrapper) seg.last();
 					final WorldLocation firstLoc = first.getFixLocation();

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/editors/PlotOutlinePage.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/editors/PlotOutlinePage.java
@@ -578,7 +578,7 @@ public class PlotOutlinePage extends Page implements IContentOutlinePage {
 					// check if this is all of the children of the element
 					final SelectionContext selectionContext = SelectionContext.create(sel);
 			
-					Editable[] selection = selectionContext.eList;
+				Editable[] selection = selectionContext.eList;
 					HasEditables[] parents = selectionContext.parentLayers;
 					
 					// if it's a single parent, check we're not trying to delete
@@ -588,11 +588,11 @@ public class PlotOutlinePage extends Page implements IContentOutlinePage {
 						if (parent instanceof CoreTMASegment) {
 							CoreTMASegment segment = (CoreTMASegment) parent;
 							if (segment.size() == selection.length ) {
-								// create a dialog with ok and cancel buttons and a question icon
+								// create a dialog with ok and cancel buttons and a warning icon
 								MessageBox dialog = 
 								    new MessageBox(getShell(), SWT.ICON_WARNING | SWT.OK| SWT.CANCEL);
 								dialog.setText("Delete Cut");
-								dialog.setMessage("You cannot delete the last cut in a TMA segment. Please delete " + 
+								dialog.setMessage("You cannot delete the last point in a TMA segment. Please delete " + 
 								" the whole segment.");
 
 								// open dialog and await user selection

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/editors/PlotOutlinePage.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/editors/PlotOutlinePage.java
@@ -37,6 +37,7 @@ import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.commands.ActionHandler;
 import org.eclipse.jface.dialogs.InputDialog;
+import org.eclipse.jface.dialogs.PopupDialog;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.IElementComparer;
@@ -52,6 +53,7 @@ import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.TextTransfer;
@@ -60,18 +62,25 @@ import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IPageLayout;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.IWorkbenchCommandConstants;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.handlers.CollapseAllHandler;
 import org.eclipse.ui.handlers.IHandlerService;
@@ -95,6 +104,7 @@ import org.mwc.debrief.core.DebriefPlugin;
 import org.mwc.debrief.core.ContextOperations.GeneratePasteRepClipboard;
 
 import Debrief.ReaderWriter.Replay.ImportReplay;
+import Debrief.Wrappers.Track.CoreTMASegment;
 import MWC.GUI.BaseLayer;
 import MWC.GUI.Editable;
 import MWC.GUI.Editable.EditorType;
@@ -545,6 +555,19 @@ public class PlotOutlinePage extends Page implements IContentOutlinePage {
 				final int count = control.getSelectionCount();
 				return count > 0;
 			}
+			
+			public Shell getShell() {
+				Shell shell = null;
+
+				final IWorkbench wb = PlatformUI.getWorkbench();
+				final IWorkbenchWindow[] windows = wb.getWorkbenchWindows();
+				if (windows.length > 0) {
+					final IWorkbenchWindow win = windows[0];
+					shell = win.getShell();
+				}
+
+				return shell;
+			};
 
 			@Override
 			public void run() {
@@ -552,8 +575,37 @@ public class PlotOutlinePage extends Page implements IContentOutlinePage {
 				final StructuredSelection sel = (StructuredSelection) _treeViewer.getSelection();
 
 				if (!sel.isEmpty()) {
+					// check if this is all of the children of the element
 					final SelectionContext selectionContext = SelectionContext.create(sel);
-					final DeleteItem deleteItem = new DeleteItem(selectionContext.eList, selectionContext.parentLayers,
+			
+					Editable[] selection = selectionContext.eList;
+					HasEditables[] parents = selectionContext.parentLayers;
+					
+					// if it's a single parent, check we're not trying to delete
+					// all children
+					if(parents.length == 1) {
+						HasEditables parent = parents[0];
+						if (parent instanceof CoreTMASegment) {
+							CoreTMASegment segment = (CoreTMASegment) parent;
+							if (segment.size() == selection.length ) {
+								// create a dialog with ok and cancel buttons and a question icon
+								MessageBox dialog = 
+								    new MessageBox(getShell(), SWT.ICON_WARNING | SWT.OK| SWT.CANCEL);
+								dialog.setText("Delete Cut");
+								dialog.setMessage("You cannot delete the last cut in a TMA segment. Please delete " + 
+								" the whole segment.");
+
+								// open dialog and await user selection
+								dialog.open();
+					
+								
+								
+								return;
+							}
+						}
+					}
+					
+					final DeleteItem deleteItem = new DeleteItem(selection, parents,
 							_myLayers, selectionContext.updateLayers);
 					deleteItem.run();
 				}
@@ -1709,5 +1761,4 @@ public class PlotOutlinePage extends Page implements IContentOutlinePage {
 			_treeViewer.setSelection(selection);
 		}
 	}
-
 }

--- a/org.mwc.debrief.core/src/org/mwc/debrief/core/editors/PlotOutlinePage.java
+++ b/org.mwc.debrief.core/src/org/mwc/debrief/core/editors/PlotOutlinePage.java
@@ -579,35 +579,48 @@ public class PlotOutlinePage extends Page implements IContentOutlinePage {
 					final SelectionContext selectionContext = SelectionContext.create(sel);
 			
 				Editable[] selection = selectionContext.eList;
-					HasEditables[] parents = selectionContext.parentLayers;
-					
-					// if it's a single parent, check we're not trying to delete
-					// all children
-					if(parents.length == 1) {
-						HasEditables parent = parents[0];
-						if (parent instanceof CoreTMASegment) {
-							CoreTMASegment segment = (CoreTMASegment) parent;
-							if (segment.size() == selection.length ) {
-								// create a dialog with ok and cancel buttons and a warning icon
-								MessageBox dialog = 
-								    new MessageBox(getShell(), SWT.ICON_WARNING | SWT.OK| SWT.CANCEL);
-								dialog.setText("Delete Cut");
-								dialog.setMessage("You cannot delete the last point in a TMA segment. Please delete " + 
-								" the whole segment.");
+				HasEditables[] parents = selectionContext.parentLayers;
 
-								// open dialog and await user selection
-								dialog.open();
-					
-								
-								
-								return;
-							}
+				// check if all items in the parents array are the same
+				boolean sameParent = true;
+				HasEditables firstParent = parents[0];
+				for (int i = 1; i < parents.length; i++) {
+					if (parents[i] != firstParent) {
+						sameParent = false;
+						break;
+					}
+				}
+
+				final HasEditables[] firstArray = {firstParent};
+				final HasEditables[] safeParents = (sameParent) ? firstArray : parents;
+				
+				// if it's a single parent, check we're not trying to delete
+				// all children
+				if(safeParents.length == 1) {
+					HasEditables parent = safeParents[0];
+					if (parent instanceof CoreTMASegment) {
+						CoreTMASegment segment = (CoreTMASegment) parent;
+						if (segment.size() == selection.length ) {
+							// create a dialog with ok and cancel buttons and a warning icon
+							MessageBox dialog = 
+							    new MessageBox(getShell(), SWT.ICON_WARNING | SWT.OK| SWT.CANCEL);
+							dialog.setText("Delete Cut");
+							dialog.setMessage("You cannot delete the last point in a TMA segment. Please delete " + 
+							" the whole segment.");
+
+							// open dialog and await user selection
+							dialog.open();
+				
+							
+							
+							return;
 						}
 					}
-					
-					final DeleteItem deleteItem = new DeleteItem(selection, parents,
-							_myLayers, selectionContext.updateLayers);
-					deleteItem.run();
+				}
+				
+				final DeleteItem deleteItem = new DeleteItem(selection, parents,
+						_myLayers, selectionContext.updateLayers);
+				deleteItem.run();
 				}
 
 			}

--- a/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/operations/ResolveAmbiguity.java
+++ b/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/operations/ResolveAmbiguity.java
@@ -172,7 +172,11 @@ public class ResolveAmbiguity implements RightClickContextItemGenerator {
 
 		for (final Editable item : subjects) {
 			if (item instanceof RelativeTMASegment) {
-				allSegments.add((RelativeTMASegment) item);
+				if ((RelativeTMASegment)item).isEmpty() {
+					return;
+				} else {
+					allSegments.add((RelativeTMASegment) item);
+				}
 			} else {
 				// not all TMA segments, drop out
 				return;

--- a/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/operations/ResolveAmbiguity.java
+++ b/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/operations/ResolveAmbiguity.java
@@ -172,7 +172,7 @@ public class ResolveAmbiguity implements RightClickContextItemGenerator {
 
 		for (final Editable item : subjects) {
 			if (item instanceof RelativeTMASegment) {
-				if ((RelativeTMASegment)item).isEmpty() {
+				if (((RelativeTMASegment)item).isEmpty()) {
 					return;
 				} else {
 					allSegments.add((RelativeTMASegment) item);

--- a/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BaseStackedDotsView.java
+++ b/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BaseStackedDotsView.java
@@ -2739,7 +2739,7 @@ abstract public class BaseStackedDotsView extends ViewPart implements
           while (iter.hasMoreElements())
           {
             final TrackSegment thisSeg = (TrackSegment) iter.nextElement();
-            if (thisSeg instanceof RelativeTMASegment)
+            if (thisSeg instanceof RelativeTMASegment && !thisSeg.isEmpty())
             {
               // do we have a first color?
               final Editable firstElement = thisSeg.elements().nextElement();


### PR DESCRIPTION
Fixes #5196 by preventing the last point in a leg being deleted.

Works for deleting points from Stacked Dots or Outline View.

Note: the underlying problem was that Debrief didn't robustly handle zero-length TMA legs.  Debrief does now handle zero-length TMA legs, though the intention of this PR is to prevent that happening.


https://github.com/user-attachments/assets/5543708e-de83-47f7-9d01-7ad096398793

