### PR TITLE
Force Java.Arrays to use legacy sort algorithm, to avoid #5199

### DIFF
--- a/org.mwc.debrief.product/debriefng.product
+++ b/org.mwc.debrief.product/debriefng.product
@@ -23,6 +23,7 @@ openFile
 -Xmx2048m
 -Duser.timezone=GMT
 -Djava.net.preferIPv4Stack=true
+-Djava.util.Arrays.useLegacyMergeSort=true
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>


### PR DESCRIPTION
Supports #5199