### PR TITLE
Add GitHub source links to SENSOR_DATA.md documentation

### DIFF
--- a/SENSOR_DATA.md
+++ b/SENSOR_DATA.md
@@ -49,106 +49,106 @@ Sensor data is fundamental to:
 
 ### 2.1 SensorContactWrapper (Individual Cut)
 
-**Source:** `org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java` (1,544 lines)
+**Source:** [`org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java) (1,544 lines)
 
 Represents a single sensor observation. Implements `Watchable`, `TimeStampedDataItem`.
 
 #### Core Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `_DTG` | `HiResDate` | Timestamp of the observation (microsecond precision) |
-| `_bearing` | `double` | Primary bearing to target (degrees, 0-360) |
-| `_hasBearing` | `boolean` | Whether bearing data is present |
-| `_bearingAmbig` | `double` | Ambiguous (second) bearing (degrees); `Double.NaN` if absent |
-| `_hasAmbiguous` | `boolean` | Whether ambiguous bearing data is active |
-| `_range` | `WorldDistance` | Range to target; `null` if not available |
-| `_freq` | `double` | Received frequency (Hz) |
-| `_hasFreq` | `boolean` | Whether frequency data is present |
-| `_absoluteOrigin` | `WorldLocation` | Explicit sensor location; `null` to derive from host track |
-| `_calculatedOrigin` | `WorldLocation` | Cached computed origin (from host track + array offset) |
-| `_trackName` | `String` | Name of the host (ownship) track |
-| `_sensorName` | `String` | Name of the parent sensor |
-| `_theLabel` | `TextLabel` | Label text and display properties |
-| `_showLabel` | `boolean` | Whether to show the label |
-| `_myLineStyle` | `int` | Line style for the bearing line (SOLID, DASHED, etc.) |
-| `_theLineLocation` | `int` | Where on the line to place the label (START, MIDDLE, END) |
-| `_mySensor` | `SensorWrapper` | Reference to parent sensor |
+| Field | Type | Description | Source |
+|-------|------|-------------|--------|
+| `_DTG` | `HiResDate` | Timestamp of the observation (microsecond precision) | [L538](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L538) |
+| `_bearing` | `double` | Primary bearing to target (degrees, 0-360) | [L550](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L550) |
+| `_hasBearing` | `boolean` | Whether bearing data is present | [L545](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L545) |
+| `_bearingAmbig` | `double` | Ambiguous (second) bearing (degrees); `Double.NaN` if absent | [L599](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L599) |
+| `_hasAmbiguous` | `boolean` | Whether ambiguous bearing data is active | [L593](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L593) |
+| `_range` | `WorldDistance` | Range to target; `null` if not available | [L543](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L543) |
+| `_freq` | `double` | Received frequency (Hz) | [L607](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L607) |
+| `_hasFreq` | `boolean` | Whether frequency data is present | [L605](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L605) |
+| `_absoluteOrigin` | `WorldLocation` | Explicit sensor location; `null` to derive from host track | [L555](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L555) |
+| `_calculatedOrigin` | `WorldLocation` | Cached computed origin (from host track + array offset) | [L560](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L560) |
+| `_trackName` | `String` | Name of the host (ownship) track | [L533](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L533) |
+| `_sensorName` | `String` | Name of the parent sensor | [L591](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L591) |
+| `_theLabel` | `TextLabel` | Label text and display properties | [L585](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L585) |
+| `_showLabel` | `boolean` | Whether to show the label | [L565](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L565) |
+| `_myLineStyle` | `int` | Line style for the bearing line (SOLID, DASHED, etc.) | [L575](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L575) |
+| `_theLineLocation` | `int` | Where on the line to place the label (START, MIDDLE, END) | [L590](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L590) |
+| `_mySensor` | `SensorWrapper` | Reference to parent sensor | [L580](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L580) |
 
 #### Key Methods
 
-| Method | Purpose |
-|--------|---------|
-| `getCalculatedOrigin(WatchableList parent)` | Computes sensor position from host track + array offset. Returns cached value or calculates from `ArrayOffsetHelper.getArrayCentre()`. Falls back to `_absoluteOrigin` if set. |
-| `getFarEnd(WorldArea outerEnvelope)` | Returns the far end of the bearing line. If range is set, uses that distance. If no range, extends to the viewport boundary (capped at 5 degrees). |
-| `getAmbiguousFarEnd(WorldArea outerEnvelope)` | Same as `getFarEnd` but for the ambiguous bearing. |
-| `paint(WatchableList track, CanvasType dest, boolean keep_simple, int alpha)` | Renders the bearing line(s) and label onto a canvas. |
-| `rangeFrom(WorldLocation other)` | Calculates minimum distance from a point to the origin, far end, or nearest point on the bearing line. Used for hit-testing. |
-| `isBearingToPort()` | Determines whether the primary bearing is to port of the host vessel's course. Cached. |
-| `ditchBearing(boolean keepPort)` | Resolves ambiguity by keeping either the port or starboard bearing and discarding the other. |
-| `relBearing(double course, double bearing)` | Static utility: calculates relative bearing (±180°) given vessel course and absolute bearing. |
-| `resetColor()` | Resets colour to `null`, causing the contact to inherit colour from its parent `SensorWrapper`. |
-| `clearCalculatedOrigin()` | Invalidates the cached origin; forces recalculation on next paint. |
+| Method | Purpose | Source |
+|--------|---------|--------|
+| `getCalculatedOrigin(WatchableList parent)` | Computes sensor position from host track + array offset. Returns cached value or calculates from `ArrayOffsetHelper.getArrayCentre()`. Falls back to `_absoluteOrigin` if set. | [L849](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L849) |
+| `getFarEnd(WorldArea outerEnvelope)` | Returns the far end of the bearing line. If range is set, uses that distance. If no range, extends to the viewport boundary (capped at 5 degrees). | [L963](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L963) |
+| `getAmbiguousFarEnd(WorldArea outerEnvelope)` | Same as `getFarEnd` but for the ambiguous bearing. | [L813](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L813) |
+| `paint(WatchableList track, CanvasType dest, boolean keep_simple, int alpha)` | Renders the bearing line(s) and label onto a canvas. | [L1202](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L1202) |
+| `rangeFrom(WorldLocation other)` | Calculates minimum distance from a point to the origin, far end, or nearest point on the bearing line. Used for hit-testing. | [L1337](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L1337) |
+| `isBearingToPort()` | Determines whether the primary bearing is to port of the host vessel's course. Cached. | [L1151](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L1151) |
+| `ditchBearing(boolean keepPort)` | Resolves ambiguity by keeping either the port or starboard bearing and discarding the other. | [L767](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L767) |
+| `relBearing(double course, double bearing)` | Static utility: calculates relative bearing (±180°) given vessel course and absolute bearing. | [L516](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L516) |
+| `resetColor()` | Resets colour to `null`, causing the contact to inherit colour from its parent `SensorWrapper`. | [L1402](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L1402) |
+| `clearCalculatedOrigin()` | Invalidates the cached origin; forces recalculation on next paint. | [L720](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L720) |
 
 #### Colour Inheritance
 
-A `SensorContactWrapper` with a `null` colour inherits the colour of its parent `SensorWrapper`. Calling `getColor()` delegates to `_mySensor.getColor()` when the contact's own colour is null. Individual contacts can override this with `setColor()`.
+A `SensorContactWrapper` with a `null` colour inherits the colour of its parent `SensorWrapper`. Calling [`getColor()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L875) delegates to `_mySensor.getColor()` when the contact's own colour is null ([L881](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L881)). Individual contacts can override this with `setColor()`.
 
 #### Comparison / Sorting
 
-Contacts are sorted by DTG within their parent `SensorWrapper`. When two contacts share the same DTG, the comparator returns `1` (not `0`) to allow multiple contacts at the same time — except when comparing the exact same object instance, which returns `0`.
+Contacts are sorted by DTG within their parent `SensorWrapper`. The [`compareTo()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L736) method compares by DTG. When two contacts share the same DTG, the comparator returns `1` (not `0`) to allow multiple contacts at the same time ([L748–L759](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L748)) — except when comparing the exact same object instance, which returns `0`.
 
 ### 2.2 SensorWrapper (Sensor Container)
 
-**Source:** `org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java` (1,639 lines)
+**Source:** [`org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java) (1,639 lines, [class declaration at L207](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L207))
 
 Container for a time-ordered collection of `SensorContactWrapper` items. Extends `TacticalDataWrapper` (which extends `PlainWrapper` and implements `Layer`).
 
 #### Core Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `_myContacts` | `SortedSet<Editable>` | Time-ordered set of `SensorContactWrapper` objects (inherited from `TacticalDataWrapper`) |
-| `_sensorOffset` | `WorldDistance.ArrayLength` | Forward/backward offset of the sensor from the platform's reference point |
-| `_arrayCentreMode` | `ArrayCentreMode` | Method used to calculate the array centre (PLAIN, WORM, or measured dataset) |
-| `_baseFrequency` | `double` | The base (transmitted) frequency of the source; used for Doppler calculations |
-| `_lastDataFrequency` | `HiResDate` | Resample interval for display thinning |
-| `_lastVisibleFrequency` | `HiResDate` | Visible frequency (how often to show cuts in the display) |
-| `_myHost` | `TrackWrapper` | Reference to the parent track (inherited from `TacticalDataWrapper`) |
-| `_additionalData` | `AdditionalData` | Supplemental data (e.g., measured array position datasets) |
+| Field | Type | Description | Source |
+|-------|------|-------------|--------|
+| `_myContacts` | `SortedSet<Editable>` | Time-ordered set of `SensorContactWrapper` objects (inherited from `TacticalDataWrapper`) | [TacticalDataWrapper](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java) |
+| `_sensorOffset` | `WorldDistance.ArrayLength` | Forward/backward offset of the sensor from the platform's reference point | [L899](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L899) |
+| `_arrayCentreMode` | `ArrayCentreMode` | Method used to calculate the array centre (PLAIN, WORM, or measured dataset) | [L906](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L906) |
+| `_baseFrequency` | `double` | The base (transmitted) frequency of the source; used for Doppler calculations | [L912](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L912) |
+| `_lastDataFrequency` | `HiResDate` | Resample interval for display thinning | [L918](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L918) |
+| `_lastVisibleFrequency` | `HiResDate` | Visible frequency (how often to show cuts in the display) | [TacticalDataWrapper L325](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java#L325) |
+| `_myHost` | `TrackWrapper` | Reference to the parent track (inherited from `TacticalDataWrapper`) | [TacticalDataWrapper](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java) |
+| `_additionalData` | `AdditionalData` | Supplemental data (e.g., measured array position datasets) | [L924](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L924) |
 
 #### Key Methods
 
-| Method | Purpose |
-|--------|---------|
-| `add(Editable)` | Adds a `SensorContactWrapper`, updates the time period, and sets the contact's sensor reference. |
-| `append(Layer, Color)` | Merges another sensor's contacts into this one. Preserves individual contact colours if different from the target sensor's default. |
-| `getNearestTo(HiResDate)` | Returns contact(s) at or nearest to the specified time. Handles multiple contacts at the same DTG. |
-| `getItemsBetween(HiResDate, HiResDate)` | Returns all contacts within a time range. |
-| `filterListTo(HiResDate, HiResDate)` | Shows/hides contacts by time window. |
-| `setResampleDataAt(HiResDate)` | Resamples (decimates) sensor data at a fixed time interval using linear interpolation of bearing, frequency, range, and ambiguous bearing. |
-| `setVisibleFrequency(HiResDate)` | Controls how frequently cuts are displayed (e.g., show every 30 seconds). |
-| `getArrayCentre(HiResDate, WorldLocation, TrackWrapper)` | Calculates the sensor array position at a given time, delegating to `ArrayOffsetHelper`. |
-| `clearChildOffsets()` | Invalidates all child contacts' cached origins; called when the sensor offset or host track changes. |
-| `makeCopy(TimeStampedDataItem)` | Deep-copies a `SensorContactWrapper` (all fields). |
-| `mergeSensors(Editable, Layers, Layer, Editable[])` | Static method to merge multiple `SensorWrapper` objects into a single target. |
+| Method | Purpose | Source |
+|--------|---------|--------|
+| `add(Editable)` | Adds a `SensorContactWrapper`, updates the time period, and sets the contact's sensor reference. | [L960](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L960) |
+| `append(Layer, Color)` | Merges another sensor's contacts into this one. Preserves individual contact colours if different from the target sensor's default. | [L978](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L978) |
+| `getNearestTo(HiResDate)` | Returns contact(s) at or nearest to the specified time. Handles multiple contacts at the same DTG. | [L1324](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L1324) |
+| `getItemsBetween(HiResDate, HiResDate)` | Returns all contacts within a time range. | [TacticalDataWrapper L617](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java#L617) |
+| `filterListTo(HiResDate, HiResDate)` | Shows/hides contacts by time window. | [TacticalDataWrapper L557](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java#L557) |
+| `setResampleDataAt(HiResDate)` | Resamples (decimates) sensor data at a fixed time interval using linear interpolation of bearing, frequency, range, and ambiguous bearing. | [L1563](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L1563) |
+| `setVisibleFrequency(HiResDate)` | Controls how frequently cuts are displayed (e.g., show every 30 seconds). | [TacticalDataWrapper L951](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java#L951) |
+| `getArrayCentre(HiResDate, WorldLocation, TrackWrapper)` | Calculates the sensor array position at a given time, delegating to `ArrayOffsetHelper`. | [L1115](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L1115) |
+| `clearChildOffsets()` | Invalidates all child contacts' cached origins; called when the sensor offset or host track changes. | [L1022](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L1022) |
+| `makeCopy(TimeStampedDataItem)` | Deep-copies a `SensorContactWrapper` (all fields). | [L1461](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L1461) |
+| `mergeSensors(Editable, Layers, Layer, Editable[])` | Static method to merge multiple `SensorWrapper` objects into a single target. | [L873](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L873) |
 
 ### 2.3 TacticalDataWrapper (Base Class)
 
-**Source:** `org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java`
+**Source:** [`org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java) ([class at L52](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java#L52))
 
 Abstract base class shared by `SensorWrapper` and `TMAWrapper`. Provides:
 
 - **Time-ordered storage**: `TreeSet<Editable>` sorted by DTG
 - **Time period tracking**: Cached `_timePeriod` (start/end DTG)
-- **Decimation/resampling**: `decimate()` method with `LinearInterpolator` that handles bearing wraparound at 0°/360°
-- **Visibility frequency**: `setVisibleFrequency()` to thin displayed cuts
-- **Layer interface**: `paint()`, `getBounds()`, `elements()`
+- **Decimation/resampling**: [`decimate()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java#L454) method with `LinearInterpolator` that handles bearing wraparound at 0°/360°
+- **Visibility frequency**: [`setVisibleFrequency()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java#L951) to thin displayed cuts
+- **Layer interface**: [`paint()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java#L744), `getBounds()`, `elements()`
 - **Host track reference**: `_myHost`, `setHost()`, `getHost()`
 
 ### 2.4 Doublet (Observation-Hypothesis Pairing)
 
-**Source:** `org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java`
+**Source:** [`org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java) ([class at L32](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L32))
 
 Pairs a sensor contact with a target fix and host fix for residual calculations.
 
@@ -163,17 +163,17 @@ Pairs a sensor contact with a target fix and host fix for residual calculations.
 
 #### Key Methods
 
-| Method | Purpose |
-|--------|---------|
-| `getMeasuredBearing()` | Returns the raw bearing from the sensor contact |
-| `getCalculatedBearing(sensorOffset, targetOffset)` | Computes the geometric bearing from sensor location to target location |
-| `calculateBearingError(measured, calculated)` | Returns error wrapped to ±180° |
-| `getMeasuredFrequency()` | Returns the raw frequency from the sensor contact |
-| `getCorrectedFrequency()` | Removes the observer's Doppler shift from the measured frequency |
-| `getPredictedFrequency(speedOfSoundKts)` | Predicts the expected frequency including the target's Doppler shift |
-| `calculateFreqError(measured, calculated)` | Returns frequency error |
-| `getAmbiguousMeasuredBearing()` | Returns the ambiguous bearing (if present) |
-| `getColor()` | Returns the colour of the sensor contact |
+| Method | Purpose | Source |
+|--------|---------|--------|
+| `getMeasuredBearing()` | Returns the raw bearing from the sensor contact | [L323](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L323) |
+| `getCalculatedBearing(sensorOffset, targetOffset)` | Computes the geometric bearing from sensor location to target location | [L246](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L246) |
+| `calculateBearingError(measured, calculated)` | Returns error wrapped to ±180° | [L156](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L156) |
+| `getMeasuredFrequency()` | Returns the raw frequency from the sensor contact | [L327](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L327) |
+| `getCorrectedFrequency()` | Removes the observer's Doppler shift from the measured frequency | [L286](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L286) |
+| `getPredictedFrequency(speedOfSoundKts)` | Predicts the expected frequency including the target's Doppler shift | [L337](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L337) |
+| `calculateFreqError(measured, calculated)` | Returns frequency error | [L175](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L175) |
+| `getAmbiguousMeasuredBearing()` | Returns the ambiguous bearing (if present) | [L233](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L233) |
+| `getColor()` | Returns the colour of the sensor contact | — |
 
 ---
 
@@ -222,7 +222,7 @@ TrackWrapper
 
 ### 4.1 REP (Replay) Format — Import
 
-Debrief supports four progressive versions of sensor lines in `.rep` files. All are registered in `ImportReplay.initialise()`.
+Debrief supports four progressive versions of sensor lines in `.rep` files. All are registered in [`ImportReplay.checkImporters()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportReplay.java#L848) (sensor importers at [L871–L873](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportReplay.java#L871), sensor arc at [L891](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportReplay.java#L891)).
 
 #### SENSOR (Version 1)
 
@@ -243,7 +243,7 @@ Debrief supports four progressive versions of sensor lines in `.rep` files. All 
 | Sensor Name | May be quoted |
 | Label | Free text to end of line |
 
-**Source:** `Debrief/ReaderWriter/Replay/ImportSensor.java`
+**Source:** [`ImportSensor.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor.java) ([class at L114](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor.java#L114), [`readThisLine()` at L230](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor.java#L230))
 
 #### SENSOR2 (Version 2) — Adds Ambiguous Bearing and Frequency
 
@@ -257,7 +257,7 @@ Additional fields vs. V1:
 - **Ambiguous Bearing** (`CCC.C`): Second bearing, or `NULL`
 - **Frequency** (`FFF.F`): Hz, or `NULL`
 
-**Source:** `Debrief/ReaderWriter/Replay/ImportSensor2.java`
+**Source:** [`ImportSensor2.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor2.java) ([class at L111](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor2.java#L111), [`readThisLine()` at L207](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor2.java#L207))
 
 #### SENSOR3 (Version 3) — Adds Accuracy Fields
 
@@ -271,7 +271,7 @@ Additional fields vs. V2:
 - **Bearing Accuracy** (`ACC.B`): Parsed but **not currently stored** in the wrapper (noted as TODO)
 - **Frequency Accuracy** (`ACC.F`): Parsed but **not currently stored**
 
-**Source:** `Debrief/ReaderWriter/Replay/ImportSensor3.java`
+**Source:** [`ImportSensor3.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor3.java) ([class at L46](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor3.java#L46), [`readThisLine()` at L138](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor3.java#L138))
 
 #### SENSORARC — Dynamic Sensor Coverage
 
@@ -281,9 +281,9 @@ Additional fields vs. V2:
 ;SENSORARC YYMMDD HHMMSS.SSS YYMMDD HHMMSS.SSS TRACKNAME @@ LEFT RIGHT INNER OUTER LABEL
 ```
 
-Creates `DynamicTrackCoverageWrapper` (visual sensor coverage fan/wedge). This is a shape, not observational data.
+Creates [`DynamicTrackCoverageWrapper`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/DynamicTrackShapes/DynamicTrackCoverageWrapper.java#L36) (visual sensor coverage fan/wedge). This is a shape, not observational data.
 
-**Source:** `Debrief/ReaderWriter/Replay/ImportSensorArc.java`
+**Source:** [`ImportSensorArc.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensorArc.java) ([class at L35](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensorArc.java#L35), [`readThisLine()` at L152](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensorArc.java#L152))
 
 **Note:** REP export of sensor contacts is **not implemented** (returns a comment line).
 
@@ -305,7 +305,7 @@ Creates `DynamicTrackCoverageWrapper` (visual sensor coverage fan/wedge). This i
 
 **Exported attributes:** Name, Visible, TrackName, LineThickness, ArrayMode, BaseFrequency, Colour, SensorOffset.
 
-**Source:** `Debrief/ReaderWriter/XML/Tactical/SensorHandler.java`
+**Source:** [`SensorHandler.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/SensorHandler.java) ([class at L33](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/SensorHandler.java#L33), [`exportSensor()` at L40](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/SensorHandler.java#L40))
 
 #### SensorContactWrapper XML
 
@@ -327,11 +327,11 @@ Creates `DynamicTrackCoverageWrapper` (visual sensor coverage fan/wedge). This i
 
 **All fields are exported and re-imported**, including: DTG, bearing, ambiguous bearing, has-ambiguous flag, frequency, has-frequency flag, range (with units), label, label visibility, label location, line style, put-label-at, colour, origin location, and comment.
 
-**Source:** `Debrief/ReaderWriter/XML/Tactical/SensorContactHandler.java`
+**Source:** [`SensorContactHandler.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/SensorContactHandler.java) ([class at L33](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/SensorContactHandler.java#L33), [`exportFix()` at L85](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/SensorContactHandler.java#L85))
 
 ### 4.3 Flat File / SAM Format — Export Only
 
-**Source:** `Debrief/ReaderWriter/FlatFile/FlatFileExporter.java`
+**Source:** [`FlatFileExporter.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/FlatFile/FlatFileExporter.java) ([class at L55](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/FlatFile/FlatFileExporter.java#L55), [`export()` at L472](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/FlatFile/FlatFileExporter.java#L472))
 
 Exports tab-separated data for Strand SAM analysis. Includes per-row: sensor status (bit flags for bearing/frequency presence), sensor XY position, bearing, frequency, bearing accuracy, frequency accuracy, and sensor type.
 
@@ -339,7 +339,7 @@ V1.01 format supports **dual sensor export** (two sensors per row).
 
 ### 4.4 Doppler Shift Export
 
-**Source:** `Debrief/ReaderWriter/FlatFile/DopplerShift/DopplerShiftExporter.java`
+**Source:** [`DopplerShiftExporter.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/FlatFile/DopplerShift/DopplerShiftExporter.java) ([class at L51](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/FlatFile/DopplerShift/DopplerShiftExporter.java#L51), [`export()` at L91](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/FlatFile/DopplerShift/DopplerShiftExporter.java#L91))
 
 Exports measured vs predicted frequency in CSV:
 ```
@@ -367,7 +367,7 @@ The first character of the 2-character symbology code maps to colours:
 
 ## 5. Rendering and Presentation
 
-### 5.1 Bearing Line Rendering (`SensorContactWrapper.paint()`)
+### 5.1 Bearing Line Rendering ([`SensorContactWrapper.paint()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L1202))
 
 The primary rendering method draws one or two bearing lines from the sensor origin to the far end.
 
@@ -396,7 +396,7 @@ When ambiguous bearing is present and active:
 - The **port** bearing is drawn in the base colour
 - The **starboard** bearing is drawn in `baseColor.darker()`
 
-This is determined by `isBearingToPort()`, which calculates the relative bearing from the host vessel's course at the contact's DTG.
+This is determined by [`isBearingToPort()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L1151), which calculates the relative bearing from the host vessel's course at the contact's DTG.
 
 ### 5.3 Transparency
 
@@ -406,7 +406,7 @@ Sensor transparency is configurable via the preference `"SensorTransparency"` (0
 
 In snail mode, sensor contacts are rendered with a **time-fading** effect:
 
-**Source:** `Debrief/GUI/Tote/Painters/SnailDrawTacticalContact.java`
+**Source:** [`SnailDrawTacticalContact.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/SnailDrawTacticalContact.java) ([class at L39](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/SnailDrawTacticalContact.java#L39), [`drawMe()` at L111](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/SnailDrawTacticalContact.java#L111))
 
 ```
 For each contact in (currentDTG - trailLength) to currentDTG:
@@ -435,7 +435,7 @@ In the Outline/Layer Manager view:
 
 ### 5.7 Multi-Line Tooltip
 
-`SensorContactWrapper` implements `MultiLineTooltipProvider`:
+`SensorContactWrapper` implements `MultiLineTooltipProvider` (via [`getMultiLineName()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L1054)):
 ```
 Sensor: [sensor_name]
 DTG: [formatted_date_time]
@@ -448,7 +448,7 @@ Track: [label]
 
 ### 6.1 SensorWrapper Properties
 
-Exposed via `SensorWrapper.SensorInfo` (implements `DynamicDescriptors` — properties change based on array mode):
+Exposed via [`SensorWrapper.SensorInfo`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java#L216) (implements `DynamicDescriptors` — properties change based on array mode):
 
 | Property | Type | Category | Description |
 |----------|------|----------|-------------|
@@ -465,7 +465,7 @@ Exposed via `SensorWrapper.SensorInfo` (implements `DynamicDescriptors` — prop
 
 ### 6.2 SensorContactWrapper Properties
 
-Exposed via `SensorContactWrapper.SensorContactInfo` (extends `Griddable`):
+Exposed via [`SensorContactWrapper.SensorContactInfo`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java#L254) (extends `Griddable`):
 
 | Property | Type | Category | Description |
 |----------|------|----------|-------------|
@@ -508,36 +508,36 @@ These are right-click menu actions available in the plot and outline views.
 
 ### 7.1 Sensor Creation
 
-**GenerateNewSensor** (`org.mwc.debrief.core/src/.../ContextOperations/GenerateNewSensor.java`)
+[**GenerateNewSensor**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateNewSensor.java) ([class at L46](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateNewSensor.java#L46))
 - **Trigger:** Right-click on a Track or "Sensors" layer
 - **Menu:** "Add new sensor"
 - **Wizard:** Collects sensor name and default colour
 - **Result:** Creates new `SensorWrapper` and adds to track
 - **Undo:** Supported (removes sensor)
 
-**GenerateNewSensorContact** (`GenerateNewSensorContact.java`)
+[**GenerateNewSensorContact**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateNewSensorContact.java) ([class at L52](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateNewSensorContact.java#L52))
 - **Trigger:** Right-click on a `SensorWrapper`
 - **Menu:** "Generate contact for this sensor"
 - **Wizard:** Collects DTG (defaults to current time), range, bearing, and colour
 - **Result:** Creates `SensorContactWrapper` and adds to sensor
 - **Undo:** Supported (removes contact)
 
-**GenerateNewInsertSensorArcAction** (`GenerateNewInsertSensorArcAction.java`)
+[**GenerateNewInsertSensorArcAction**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateNewInsertSensorArcAction.java) ([class at L60](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateNewInsertSensorArcAction.java#L60))
 - **Trigger:** Right-click on a `TrackWrapper`
 - **Menu:** "Insert new Sensor Arc"
 - **Wizard:** Collects start/end times, arc bounds (left/right angles, inner/outer range), and styling
-- **Result:** Creates `DynamicTrackCoverageWrapper` (visual sensor coverage fan)
+- **Result:** Creates [`DynamicTrackCoverageWrapper`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/DynamicTrackShapes/DynamicTrackCoverageWrapper.java#L36) (visual sensor coverage fan)
 - **Undo:** Supported
 
 ### 7.2 Sensor Data Manipulation
 
-**MergeContacts** (`MergeContacts.java`)
+[**MergeContacts**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/MergeContacts.java) ([class at L39](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/MergeContacts.java#L39))
 - **Trigger:** Select 2+ `SensorWrapper` objects
 - **Menu:** "Merge sensors into [first sensor name]"
 - **Behaviour:** All contacts from source sensors are transferred to the target sensor. Individual contact colours are preserved if they differ from the target's default colour.
 - **Undo:** NOT supported (irreversible)
 
-**RainbowShadeSonarCuts** (`RainbowShadeSonarCuts.java`)
+[**RainbowShadeSonarCuts**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/RainbowShadeSonarCuts.java) ([class at L46](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/RainbowShadeSonarCuts.java#L46))
 - **Trigger:** Select sensor(s) or sensor contact(s)
 - **Menu:** Submenu "Shading" with three options:
   - "Shade in rainbow colors" — Maps time to hue (HSB colour space)
@@ -547,19 +547,19 @@ These are right-click menu actions available in the plot and outline views.
 
 ### 7.3 Sensor Analysis
 
-**GenerateSensorRangePlot** (`GenerateSensorRangePlot.java`)
+[**GenerateSensorRangePlot**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateSensorRangePlot.java) ([class at L70](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateSensorRangePlot.java#L70))
 - **Trigger:** Select sensor(s) AND track(s)
 - **Menu:** "View sensor range plot (one sensor versus one track)" (and variants for multiple)
 - **Behaviour:** Calculates range from sensor array centre to track position at each fix time. Displays as JFreeChart time-series plot.
 
-**CopyBearingsToClipboard** (`CopyBearingsToClipboard.java`)
+[**CopyBearingsToClipboard**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/CopyBearingsToClipboard.java) ([class at L92](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/CopyBearingsToClipboard.java#L92))
 - **Trigger:** Select tracks with `RelativeTMASegment` data
 - **Menu:** "Copy [tracks] to clipboard as offsets from [reference track]" / "Create new [tracks] by adding clipboard bearings to [track]"
 - **Behaviour:** Extracts bearing/position offsets between tracks via the system clipboard. Paste creates new tracks by applying offsets to a reference track.
 
 ### 7.4 TMA from Sensors
 
-**GenerateTMASegmentFromCuts** (`GenerateTMASegmentFromCuts.java`)
+[**GenerateTMASegmentFromCuts**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTMASegmentFromCuts.java) ([class at L82](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTMASegmentFromCuts.java#L82))
 - **Trigger:** Select sensor(s) or sensor contact(s)
 - **Menu:** "Generate TMA solution from all cuts" / "Generate TMA solution from selected cuts"
 - **Wizard:** Collects range, bearing offset, target course, speed, and optional colour override
@@ -576,16 +576,16 @@ The **Bearing Residuals View** (`BearingResidualsView`) provides the primary too
 
 ### 8.1 Architecture
 
-**Source:** `org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/`
+**Source:** [`org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/)
 
-| Class | Purpose |
-|-------|---------|
-| `BaseStackedDotsView` | Abstract base for all residual views; manages chart layout, track selection, and zone display |
-| `BearingResidualsView` | Concrete view showing bearing residual dots |
-| `FrequencyResidualsView` | Concrete view showing frequency residual dots |
-| `StackedDotHelper` | Utility class that creates `Doublet` pairings and calculates residual data series |
+| Class | Purpose | Source |
+|-------|---------|--------|
+| `BaseStackedDotsView` | Abstract base for all residual views; manages chart layout, track selection, and zone display | [L203](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BaseStackedDotsView.java#L203) |
+| `BearingResidualsView` | Concrete view showing bearing residual dots | [L87](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BearingResidualsView.java#L87) |
+| `FrequencyResidualsView` | Concrete view showing frequency residual dots | [L74](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/FrequencyResidualsView.java#L74) |
+| `StackedDotHelper` | Utility class that creates `Doublet` pairings and calculates residual data series | [L97](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/StackedDotHelper.java#L97) |
 
-### 8.2 Doublet Generation (`StackedDotHelper.getDoublets()`)
+### 8.2 Doublet Generation ([`StackedDotHelper.getDoublets()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/StackedDotHelper.java#L1251))
 
 The algorithm pairs sensor contacts with target track fixes:
 
@@ -621,7 +621,7 @@ If a contact has an ambiguous bearing, a second residual is calculated using `ge
 ### 8.5 Zone Detection (Ownship Legs)
 
 The `StackedDotHelper` includes **ownship leg detection** algorithms:
-- `PeakTrackingOwnshipLegDetector` — Detects straight-line legs in the ownship track
+- [`PeakTrackingOwnshipLegDetector`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/zig_detector/ownship/PeakTrackingOwnshipLegDetector.java#L30) — Detects straight-line legs in the ownship track
 - `ArtificalLegDetector` — An alternative algorithm
 - `AlternateLegWrapper` — Wraps detected legs for display
 
@@ -641,7 +641,7 @@ The helper produces `TimeSeriesCollection` datasets containing:
 
 ### 9.1 FrequencyResidualsView
 
-**Source:** `org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/FrequencyResidualsView.java`
+**Source:** [`FrequencyResidualsView.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/FrequencyResidualsView.java) ([class at L74](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/FrequencyResidualsView.java#L74))
 
 Extends `BaseStackedDotsView` to display frequency residuals.
 
@@ -651,28 +651,28 @@ For each `Doublet`:
 
 1. **Measured frequency** = `sensor.getFrequency()` (raw received frequency)
 2. **Base frequency** = `sensor.getSensor().getBaseFrequency()` (transmitted frequency of source)
-3. **Corrected frequency** = Removes the **observer's** Doppler shift:
+3. **Corrected frequency** = Removes the **observer's** Doppler shift (via [`getCorrectedFrequency()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L286)):
    ```
    dopplerComponent = calcDopplerComponent(bearingRads, hostCourseRads, hostSpeedKts, measuredFreq)
    correctedFreq = measuredFreq + dopplerComponent
    ```
-4. **Predicted frequency** = Adds the **target's** Doppler shift based on the TMA solution's course/speed:
+4. **Predicted frequency** = Adds the **target's** Doppler shift based on the TMA solution's course/speed (via [`getPredictedFrequency()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L337)):
    ```
-   predictedFreq = calcPredictedFreq(baseFreq, targetCourse, targetSpeed, bearing, speedOfSound)
+   predictedFreq = calcPredictedFreqSI(baseFreq, targetCourse, targetSpeed, bearing, speedOfSound)
    ```
 5. **Frequency error** = `corrected - predicted`
 
 ### 9.3 `FrequencyCalcs` Utility
 
-**Source:** `MWC.Algorithms.FrequencyCalcs`
+**Source:** [`MWC.Algorithms.FrequencyCalcs`](https://github.com/debrief/debrief/blob/master/org.mwc.cmap.legacy/src/MWC/Algorithms/FrequencyCalcs.java) ([class at L20](https://github.com/debrief/debrief/blob/master/org.mwc.cmap.legacy/src/MWC/Algorithms/FrequencyCalcs.java#L20))
 
 Provides:
-- `calcDopplerComponent()`: Doppler shift from relative motion along the bearing line
-- `calcPredictedFreq()`: Expected received frequency given base freq, relative geometry, and speed of sound
+- [`calcDopplerComponent()`](https://github.com/debrief/debrief/blob/master/org.mwc.cmap.legacy/src/MWC/Algorithms/FrequencyCalcs.java#L296): Doppler shift from relative motion along the bearing line
+- [`calcPredictedFreqSI()`](https://github.com/debrief/debrief/blob/master/org.mwc.cmap.legacy/src/MWC/Algorithms/FrequencyCalcs.java#L323): Expected received frequency given base freq, relative geometry, and speed of sound
 
 ### 9.4 Multistatic Support
 
-`Doublet.getPredictedMultistaticFrequency()` supports two-way propagation (source and receiver both in motion), used for active sonar scenarios.
+[`Doublet.getPredictedMultistaticFrequency()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java#L357) supports two-way propagation (source and receiver both in motion), used for active sonar scenarios.
 
 ---
 
@@ -680,29 +680,29 @@ Provides:
 
 ### 10.1 TMAContactWrapper (Individual TMA Solution)
 
-**Source:** `org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java` (1,309 lines)
+**Source:** [`org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java) (1,309 lines, [class at L128](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L128))
 
 Represents a single TMA solution at a specific time.
 
 #### Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `_DTG` | `HiResDate` | Timestamp |
-| `_targetBrgRads` | `double` | Bearing to target (radians) |
-| `_targetRange` | `WorldDistance` | Range to target |
-| `_targetCourseDegs` | `double` | Target course estimate (degrees) |
-| `_targetSpeedKts` | `double` | Target speed estimate (knots) |
-| `_targetDepth` | `double` | Target depth estimate |
-| `_theEllipse` | `EllipseShape` | Uncertainty ellipse |
-| `_showLine` | `Boolean` | Whether to show bearing line from ownship to solution |
-| `_showSymbol` | `boolean` | Whether to show symbol at solution location |
-| `_showVector` | `boolean` | Whether to show target velocity vector |
-| `_originalLocation` | `WorldLocation` | Absolute location (for absolute TMA mode) |
+| Field | Type | Description | Source |
+|-------|------|-------------|--------|
+| `_DTG` | `HiResDate` | Timestamp | [L335](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L335) |
+| `_targetBrgRads` | `double` | Bearing to target (radians) | [L341](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L341) |
+| `_targetRange` | `WorldDistance` | Range to target | [L347](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L347) |
+| `_targetCourseDegs` | `double` | Target course estimate (degrees) | [L397](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L397) |
+| `_targetSpeedKts` | `double` | Target speed estimate (knots) | [L402](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L402) |
+| `_targetDepth` | `double` | Target depth estimate | [L352](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L352) |
+| `_theEllipse` | `EllipseShape` | Uncertainty ellipse | [L382](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L382) |
+| `_showLine` | `Boolean` | Whether to show bearing line from ownship to solution | [L367](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L367) |
+| `_showSymbol` | `boolean` | Whether to show symbol at solution location | [L362](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L362) |
+| `_showVector` | `boolean` | Whether to show target velocity vector | [L416](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L416) |
+| `_originalLocation` | `WorldLocation` | Absolute location (for absolute TMA mode) | [L422](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L422) |
 
 #### Rendering
 
-`TMAContactWrapper.paint()` draws:
+[`TMAContactWrapper.paint()`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L1019) draws:
 1. **Bearing line** from ownship position to solution centre
 2. **Uncertainty ellipse** at the solution position
 3. **Symbol** at the solution position (optional)
@@ -710,20 +710,20 @@ Represents a single TMA solution at a specific time.
 
 #### Position Calculation
 
-`getCentre(WatchableList track)` computes the TMA solution position:
+[`getCentre(WatchableList track)`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java#L659) computes the TMA solution position:
 - For **relative** TMA: host track position + offset (range/bearing)
 - For **absolute** TMA: uses `_originalLocation` directly
 
 ### 10.2 TMAWrapper (TMA Solution Container)
 
-**Source:** `org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAWrapper.java` (777 lines)
+**Source:** [`org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAWrapper.java) (777 lines, [class at L96](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAWrapper.java#L96))
 
 Container for a time-ordered collection of `TMAContactWrapper` objects. Extends `TacticalDataWrapper` (same base class as `SensorWrapper`).
 
 Key properties:
-- **Show Bearing Lines** (`_showBearingLines`): Toggle for all solutions
-- **Show Labels** (`_showLabels`): Toggle for all labels
-- `getNearestTo(HiResDate)`: Finds solution(s) at/near a time
+- **Show Bearing Lines** ([`_showBearingLines`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAWrapper.java#L441)): Toggle for all solutions
+- **Show Labels** ([`_showLabels`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAWrapper.java#L454)): Toggle for all labels
+- [`getNearestTo(HiResDate)`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAWrapper.java#L623): Finds solution(s) at/near a time
 
 ---
 
@@ -740,17 +740,17 @@ TrackSegment (base track segment)
 
 ### 11.2 CoreTMASegment (Abstract Base)
 
-**Source:** `org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java` (336 lines)
+**Source:** [`org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java) (336 lines, [class at L43](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java#L43))
 
 Represents a TMA solution as a constant-course, constant-speed target hypothesis. Unlike a regular `TrackSegment` (which stores individual fixes), a TMA segment **generates** fix positions by dead-reckoning from an origin at a constant course and speed.
 
 #### Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `_courseDegs` | `double` | Constant target course (degrees) |
-| `_speed` | `WorldSpeed` | Constant target speed |
-| `_dragMsg` | `String` | Real-time feedback during interactive drag (e.g., "[120° 12 kts]") |
+| Field | Type | Description | Source |
+|-------|------|-------------|--------|
+| `_courseDegs` | `double` | Constant target course (degrees) | [L62](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java#L62) |
+| `_speed` | `WorldSpeed` | Constant target speed | [L67](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java#L67) |
+| `_dragMsg` | `String` | Real-time feedback during interactive drag (e.g., "[120° 12 kts]") | — |
 
 #### Interactive Drag Operations
 
@@ -758,53 +758,53 @@ TMA segments support four drag modes, each of which is fundamental to the manual
 
 | Operation | Method | Effect | Drag Message |
 |-----------|--------|--------|-------------|
-| **Translate** | `shift(WorldVector)` | Moves the entire segment without changing course/speed | — |
-| **Rotate** | `rotate(double, WorldLocation)` | Changes course by rotating about an endpoint | `"[newCourse°]"` |
-| **Stretch** | `stretch(double, WorldLocation)` | Changes speed by stretching/compressing along the bearing | `"[newSpeed kts]"` |
-| **Shear** | `shear(WorldLocation, WorldLocation)` | Changes both course and speed simultaneously | `"[speed kts newCourse°]"` |
+| **Translate** | [`shift(WorldVector)`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java#L288) | Moves the entire segment without changing course/speed | — |
+| **Rotate** | [`rotate(double, WorldLocation)`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java#L223) | Changes course by rotating about an endpoint | `"[newCourse°]"` |
+| **Stretch** | [`stretch(double, WorldLocation)`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java#L296) | Changes speed by stretching/compressing along the bearing | `"[newSpeed kts]"` |
+| **Shear** | [`shear(WorldLocation, WorldLocation)`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java#L285) | Changes both course and speed simultaneously | `"[speed kts newCourse°]"` |
 
 These operations provide real-time visual feedback via the `_dragMsg` field, which is displayed near the cursor during dragging.
 
 ### 11.3 AbsoluteTMASegment
 
-**Source:** `org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/AbsoluteTMASegment.java` (457 lines)
+**Source:** [`org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/AbsoluteTMASegment.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/AbsoluteTMASegment.java) (457 lines, [class at L38](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/AbsoluteTMASegment.java#L38))
 
 A TMA segment anchored at an **absolute geographic position**.
 
 #### Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `_origin` | `WorldLocation` | Fixed starting point (lat/lon) |
-| `_startTime` | `HiResDate` | Start time |
-| `_endTime` | `HiResDate` | End time |
+| Field | Type | Description | Source |
+|-------|------|-------------|--------|
+| `_origin` | `WorldLocation` | Fixed starting point (lat/lon) | [L91](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/AbsoluteTMASegment.java#L91) |
+| `_startTime` | `HiResDate` | Start time | [L87](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/AbsoluteTMASegment.java#L87) |
+| `_endTime` | `HiResDate` | End time | [L89](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/AbsoluteTMASegment.java#L89) |
 
 #### Fix Generation
 
-`createFixAt(long theTime, long startTime)`:
+[`createFixAt(long theTime, long startTime)`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/AbsoluteTMASegment.java#L210):
 - Calculates elapsed time from origin
 - Dead-reckons position: origin + (speed × time) along course
 - Returns a `Fix` at the computed location
 
 ### 11.4 RelativeTMASegment
 
-**Source:** `org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java` (>1,500 lines)
+**Source:** [`org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java) (>1,500 lines, [class at L60](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java#L60))
 
 A TMA segment defined **relative to a reference track** (the ownship). This is the most commonly used TMA segment type, as it maintains the spatial relationship between ownship and the target hypothesis.
 
 #### Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `_referenceTrackName` | `String` | Name of the ownship track |
-| `_referenceSensorName` | `String` | Optional: sensor used for offset |
-| `_offset` | `WorldVector` | Initial offset from ownship at start time |
-| `_referenceTrack` | `TrackWrapper` | Runtime reference to ownship track |
-| `_referenceSensor` | `SensorWrapper` | Optional: sensor for array offset |
+| Field | Type | Description | Source |
+|-------|------|-------------|--------|
+| `_referenceTrackName` | `String` | Name of the ownship track | [L148](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java#L148) |
+| `_referenceSensorName` | `String` | Optional: sensor used for offset | [L155](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java#L155) |
+| `_offset` | `WorldVector` | Initial offset from ownship at start time | [L161](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java#L161) |
+| `_referenceTrack` | `TrackWrapper` | Runtime reference to ownship track | [L167](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java#L167) |
+| `_referenceSensor` | `SensorWrapper` | Optional: sensor for array offset | [L173](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java#L173) |
 
 #### Construction from Sensor Contacts
 
-The most important constructor takes an array of `SensorContactWrapper` objects:
+The most important constructor takes an array of `SensorContactWrapper` objects ([L252](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java#L252)):
 ```java
 RelativeTMASegment(SensorContactWrapper[] observations, WorldVector offset,
                    WorldSpeed speed, double course, Layers layers)
@@ -826,7 +826,7 @@ The offset is recalculated when the ownship track moves, ensuring the TMA soluti
 
 ### 11.5 Creating TMA from Sensor Cuts (Workflow)
 
-**Source:** `org.mwc.debrief.core/src/.../ContextOperations/GenerateTMASegmentFromCuts.java` (1,029 lines)
+**Source:** [`GenerateTMASegmentFromCuts.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTMASegmentFromCuts.java) (1,029 lines, [class at L82](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTMASegmentFromCuts.java#L82))
 
 This is the primary "Manual TMA" workflow:
 
@@ -844,33 +844,33 @@ This is the primary "Manual TMA" workflow:
 
 ### 11.6 Other TMA Generation Methods
 
-**GenerateTMASegmentFromOwnshipPositions** (`GenerateTMASegmentFromOwnshipPositions.java`)
+[**GenerateTMASegmentFromOwnshipPositions**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTMASegmentFromOwnshipPositions.java) ([class at L61](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTMASegmentFromOwnshipPositions.java#L61))
 - Creates `AbsoluteTMASegment` from selected ownship fixes + user offset
 - Used when the analyst wants to place a TMA solution at a known position relative to ownship fixes
 
-**GenerateTMASegmentFromInfillSegment** (`GenerateTMASegmentFromInfillSegment.java`)
+[**GenerateTMASegmentFromInfillSegment**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTMASegmentFromInfillSegment.java) ([class at L56](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTMASegmentFromInfillSegment.java#L56))
 - Replaces a `DynamicInfillSegment` (interpolated gap fill) with an explicit `AbsoluteTMASegment`
 - Used to formalise an interpolated section as a TMA solution
 
-**ConvertAbsoluteTmaToRelative** (`ConvertAbsoluteTmaToRelative.java`)
+[**ConvertAbsoluteTmaToRelative**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/ConvertAbsoluteTmaToRelative.java) ([class at L63](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/ConvertAbsoluteTmaToRelative.java#L63))
 - Converts an `AbsoluteTMASegment` to a `RelativeTMASegment`
 - Calculates the offset from the sensor array centre at the start time
 
-**SelectCutsForThisTMASegment** / **ShowCutsForThisTMASegment**
+[**SelectCutsForThisTMASegment**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/SelectCutsForThisTMASegment.java#L48) / [**ShowCutsForThisTMASegment**](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/ShowCutsForThisTMASegment.java#L53)
 - Highlights/colours sensor cuts that correspond to a TMA solution's time period
 
 ### 11.7 Interactive TMA Drag
 
-**Source:** `org.mwc.debrief.core/src/.../actions/DragSegment.java` (258 lines)
+**Source:** [`DragSegment.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragSegment.java) (258 lines, [class at L55](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragSegment.java#L55))
 
 **Drag modes** (available when a TMA segment is selected in the plot):
 
-| Mode | Cursor | Action | Changes |
-|------|--------|--------|---------|
-| **Translate** | Move cursor | `segment.shift(vector)` | Position only |
-| **Rotate** | Rotate cursor | `segment.rotate(angle, origin)` | Course |
-| **Stretch** | Stretch cursor | `segment.stretch(range, origin)` | Speed |
-| **Shear** (default) | Shear cursor | `segment.shear(cursor, origin)` | Course + Speed |
+| Mode | Cursor | Action | Changes | Source |
+|------|--------|--------|---------|--------|
+| **Translate** | Move cursor | `segment.shift(vector)` | Position only | [`CoreDragOperation`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/drag/CoreDragOperation.java#L50) |
+| **Rotate** | Rotate cursor | `segment.rotate(angle, origin)` | Course | [`RotateDragMode`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/drag/RotateDragMode.java#L40) |
+| **Stretch** | Stretch cursor | `segment.stretch(range, origin)` | Speed | [`StretchDragMode`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/drag/StretchDragMode.java#L30) |
+| **Shear** (default) | Shear cursor | `segment.shear(cursor, origin)` | Course + Speed | [`ShearDragMode`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/drag/ShearDragMode.java#L30) |
 
 During dragging:
 - The segment's `getDragTextMessage()` returns a live text summary (e.g., "[12.5 kts 045°]")
@@ -887,20 +887,21 @@ Sensors (especially towed sonar arrays) are physically offset from the vessel's 
 
 ### 12.2 ArrayOffsetHelper
 
-**Source:** `org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/ArrayOffsetHelper.java`
+**Source:** [`org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/ArrayOffsetHelper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/ArrayOffsetHelper.java) ([class at L34](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/ArrayOffsetHelper.java#L34))
 
 #### Array Centre Modes
 
-| Mode | Enum/Class | Behaviour |
-|------|-----------|-----------|
-| **PLAIN** | `LegacyArrayOffsetModes.PLAIN` | Array centre at a fixed distance along the vessel's current heading (simple backtrack) |
-| **WORM** | `LegacyArrayOffsetModes.WORM` | "Worm in hole": array centre follows the vessel's historical track. The centre is placed at the vessel's position from N metres of track distance ago. Accurately models a towed array that follows the vessel's path through the water. |
-| **Measured** | `MeasuredDatasetArrayMode` | Uses actual measured position data (from a time-series dataset) for the array centre location. Supports absolute positions (lat/lon) or relative offsets (metres). |
-| **Deferred** | `DeferredDatasetArrayMode` | Placeholder for datasets that haven't been loaded yet; resolved later. |
+| Mode | Enum/Class | Behaviour | Source |
+|------|-----------|-----------|--------|
+| **PLAIN** | `LegacyArrayOffsetModes.PLAIN` | Array centre at a fixed distance along the vessel's current heading (simple backtrack) | [L64](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/ArrayOffsetHelper.java#L64) |
+| **WORM** | `LegacyArrayOffsetModes.WORM` | "Worm in hole": array centre follows the vessel's historical track. The centre is placed at the vessel's position from N metres of track distance ago. Accurately models a towed array that follows the vessel's path through the water. | [L71](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/ArrayOffsetHelper.java#L71) |
+| **Measured** | `MeasuredDatasetArrayMode` | Uses actual measured position data (from a time-series dataset) for the array centre location. Supports absolute positions (lat/lon) or relative offsets (metres). | [L80](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/ArrayOffsetHelper.java#L80) |
+| **Deferred** | `DeferredDatasetArrayMode` | Placeholder for datasets that haven't been loaded yet; resolved later. | [L46](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/ArrayOffsetHelper.java#L46) |
 
 #### Calculation Flow
 
 ```java
+// See: ArrayOffsetHelper.getArrayCentre() at L141
 ArrayOffsetHelper.getArrayCentre(sensor, time, hostLocation, track):
   mode = sensor.getArrayCentreMode()
   if mode == LEGACY (PLAIN or WORM):
@@ -927,70 +928,73 @@ When the sensor offset or array mode changes, `clearChildOffsets()` invalidates 
 
 | File | Lines | Description |
 |------|-------|-------------|
-| `org.mwc.debrief.legacy/.../Wrappers/SensorContactWrapper.java` | 1,544 | Individual sensor observation |
-| `org.mwc.debrief.legacy/.../Wrappers/SensorWrapper.java` | 1,639 | Sensor container |
-| `org.mwc.debrief.legacy/.../Wrappers/TacticalDataWrapper.java` | ~800 | Base class for sensor/TMA containers |
-| `org.mwc.debrief.legacy/.../Wrappers/TMAContactWrapper.java` | 1,309 | Individual TMA solution |
-| `org.mwc.debrief.legacy/.../Wrappers/TMAWrapper.java` | 777 | TMA solution container |
-| `org.mwc.debrief.legacy/.../Wrappers/Track/Doublet.java` | ~400 | Observation-hypothesis pairing |
-| `org.mwc.debrief.legacy/.../Wrappers/Track/CoreTMASegment.java` | 336 | Abstract TMA segment |
-| `org.mwc.debrief.legacy/.../Wrappers/Track/AbsoluteTMASegment.java` | 457 | Absolute TMA segment |
-| `org.mwc.debrief.legacy/.../Wrappers/Track/RelativeTMASegment.java` | >1,500 | Relative TMA segment |
-| `org.mwc.debrief.legacy/.../Wrappers/Track/ArrayOffsetHelper.java` | ~300 | Array centre calculations |
+| [`SensorContactWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorContactWrapper.java) | 1,544 | Individual sensor observation |
+| [`SensorWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/SensorWrapper.java) | 1,639 | Sensor container |
+| [`TacticalDataWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TacticalDataWrapper.java) | ~800 | Base class for sensor/TMA containers |
+| [`TMAContactWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAContactWrapper.java) | 1,309 | Individual TMA solution |
+| [`TMAWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/TMAWrapper.java) | 777 | TMA solution container |
+| [`Doublet.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/Doublet.java) | ~400 | Observation-hypothesis pairing |
+| [`CoreTMASegment.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/CoreTMASegment.java) | 336 | Abstract TMA segment |
+| [`AbsoluteTMASegment.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/AbsoluteTMASegment.java) | 457 | Absolute TMA segment |
+| [`RelativeTMASegment.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/RelativeTMASegment.java) | >1,500 | Relative TMA segment |
+| [`ArrayOffsetHelper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/ArrayOffsetHelper.java) | ~300 | Array centre calculations |
 
 ### Import / Export
 
 | File | Description |
 |------|-------------|
-| `org.mwc.debrief.legacy/.../ReaderWriter/Replay/ImportSensor.java` | REP v1 import |
-| `org.mwc.debrief.legacy/.../ReaderWriter/Replay/ImportSensor2.java` | REP v2 import (+ ambig bearing, freq) |
-| `org.mwc.debrief.legacy/.../ReaderWriter/Replay/ImportSensor3.java` | REP v3 import (+ accuracy fields) |
-| `org.mwc.debrief.legacy/.../ReaderWriter/Replay/ImportSensorArc.java` | Sensor arc import |
-| `org.mwc.debrief.legacy/.../ReaderWriter/XML/Tactical/SensorHandler.java` | XML sensor import/export |
-| `org.mwc.debrief.legacy/.../ReaderWriter/XML/Tactical/SensorContactHandler.java` | XML contact import/export |
-| `org.mwc.debrief.legacy/.../ReaderWriter/FlatFile/FlatFileExporter.java` | SAM flat file export |
-| `org.mwc.debrief.legacy/.../ReaderWriter/FlatFile/DopplerShift/DopplerShiftExporter.java` | Doppler export |
+| [`ImportSensor.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor.java) | REP v1 import |
+| [`ImportSensor2.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor2.java) | REP v2 import (+ ambig bearing, freq) |
+| [`ImportSensor3.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensor3.java) | REP v3 import (+ accuracy fields) |
+| [`ImportSensorArc.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportSensorArc.java) | Sensor arc import |
+| [`SensorHandler.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/SensorHandler.java) | XML sensor import/export |
+| [`SensorContactHandler.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/XML/Tactical/SensorContactHandler.java) | XML contact import/export |
+| [`FlatFileExporter.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/FlatFile/FlatFileExporter.java) | SAM flat file export |
+| [`DopplerShiftExporter.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/FlatFile/DopplerShift/DopplerShiftExporter.java) | Doppler export |
+| [`ImportReplay.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportReplay.java) | Main replay importer (sensor registration at [L871](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/ReaderWriter/Replay/ImportReplay.java#L871)) |
 
 ### Analysis
 
 | File | Description |
 |------|-------------|
-| `org.mwc.debrief.track_shift/.../views/BaseStackedDotsView.java` | Abstract residual view |
-| `org.mwc.debrief.track_shift/.../views/BearingResidualsView.java` | Bearing residual stacked dots |
-| `org.mwc.debrief.track_shift/.../views/FrequencyResidualsView.java` | Frequency residual stacked dots |
-| `org.mwc.debrief.track_shift/.../views/StackedDotHelper.java` | Doublet generation and data series |
-| `MWC.Algorithms.FrequencyCalcs` | Doppler shift calculations |
+| [`BaseStackedDotsView.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BaseStackedDotsView.java) | Abstract residual view |
+| [`BearingResidualsView.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/BearingResidualsView.java) | Bearing residual stacked dots |
+| [`FrequencyResidualsView.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/FrequencyResidualsView.java) | Frequency residual stacked dots |
+| [`StackedDotHelper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.track_shift/src/org/mwc/debrief/track_shift/views/StackedDotHelper.java) | Doublet generation and data series |
+| [`FrequencyCalcs.java`](https://github.com/debrief/debrief/blob/master/org.mwc.cmap.legacy/src/MWC/Algorithms/FrequencyCalcs.java) | Doppler shift calculations |
 
 ### Context Operations
 
 | File | Description |
 |------|-------------|
-| `org.mwc.debrief.core/.../ContextOperations/GenerateNewSensor.java` | Create sensor |
-| `org.mwc.debrief.core/.../ContextOperations/GenerateNewSensorContact.java` | Create contact |
-| `org.mwc.debrief.core/.../ContextOperations/MergeContacts.java` | Merge sensors |
-| `org.mwc.debrief.core/.../ContextOperations/RainbowShadeSonarCuts.java` | Colour-shade contacts |
-| `org.mwc.debrief.core/.../ContextOperations/GenerateSensorRangePlot.java` | Range plot |
-| `org.mwc.debrief.core/.../ContextOperations/GenerateTMASegmentFromCuts.java` | TMA from cuts |
-| `org.mwc.debrief.core/.../ContextOperations/GenerateTMASegmentFromOwnshipPositions.java` | TMA from fixes |
-| `org.mwc.debrief.core/.../ContextOperations/ConvertAbsoluteTmaToRelative.java` | Convert TMA type |
-| `org.mwc.debrief.core/.../ContextOperations/CopyBearingsToClipboard.java` | Copy/paste bearings |
-| `org.mwc.debrief.core/.../ContextOperations/SelectCutsForThisTMASegment.java` | Select cuts for TMA |
-| `org.mwc.debrief.core/.../ContextOperations/ShowCutsForThisTMASegment.java` | Highlight cuts for TMA |
+| [`GenerateNewSensor.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateNewSensor.java) | Create sensor |
+| [`GenerateNewSensorContact.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateNewSensorContact.java) | Create contact |
+| [`MergeContacts.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/MergeContacts.java) | Merge sensors |
+| [`RainbowShadeSonarCuts.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/RainbowShadeSonarCuts.java) | Colour-shade contacts |
+| [`GenerateSensorRangePlot.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateSensorRangePlot.java) | Range plot |
+| [`GenerateTMASegmentFromCuts.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTMASegmentFromCuts.java) | TMA from cuts |
+| [`GenerateTMASegmentFromOwnshipPositions.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateTMASegmentFromOwnshipPositions.java) | TMA from fixes |
+| [`ConvertAbsoluteTmaToRelative.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/ConvertAbsoluteTmaToRelative.java) | Convert TMA type |
+| [`CopyBearingsToClipboard.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/CopyBearingsToClipboard.java) | Copy/paste bearings |
+| [`SelectCutsForThisTMASegment.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/SelectCutsForThisTMASegment.java) | Select cuts for TMA |
+| [`ShowCutsForThisTMASegment.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/ShowCutsForThisTMASegment.java) | Highlight cuts for TMA |
+| [`GenerateNewInsertSensorArcAction.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/ContextOperations/GenerateNewInsertSensorArcAction.java) | Insert sensor arc |
 
 ### Drag Operations
 
 | File | Description |
 |------|-------------|
-| `org.mwc.debrief.core/.../actions/DragSegment.java` | TMA drag entry point |
-| `org.mwc.debrief.core/.../actions/drag/CoreDragOperation.java` | Drag base class |
-| `org.mwc.debrief.core/.../actions/drag/ShearDragMode.java` | Shear drag (course + speed) |
-| `org.mwc.debrief.core/.../actions/drag/RotateDragMode.java` | Rotate drag (course) |
-| `org.mwc.debrief.core/.../actions/drag/StretchDragMode.java` | Stretch drag (speed) |
+| [`DragSegment.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragSegment.java) | TMA drag entry point |
+| [`CoreDragOperation.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/drag/CoreDragOperation.java) | Drag base class |
+| [`ShearDragMode.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/drag/ShearDragMode.java) | Shear drag (course + speed) |
+| [`RotateDragMode.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/drag/RotateDragMode.java) | Rotate drag (course) |
+| [`StretchDragMode.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/actions/drag/StretchDragMode.java) | Stretch drag (speed) |
 
 ### Rendering
 
 | File | Description |
 |------|-------------|
-| `org.mwc.debrief.legacy/.../GUI/Tote/Painters/SnailDrawTacticalContact.java` | Snail mode sensor rendering |
-| `org.mwc.debrief.legacy/.../GUI/Tote/Painters/SnailDrawTMAContact.java` | Snail mode TMA rendering |
-| `org.mwc.debrief.core/.../editors/painters/snail/SnailDrawSWTSensorContact.java` | SWT sensor rendering |
+| [`SnailDrawTacticalContact.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/SnailDrawTacticalContact.java) | Snail mode sensor rendering |
+| [`SnailDrawTMAContact.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/GUI/Tote/Painters/SnailDrawTMAContact.java) | Snail mode TMA rendering |
+| [`SnailDrawSWTSensorContact.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.core/src/org/mwc/debrief/core/editors/painters/snail/SnailDrawSWTSensorContact.java) | SWT sensor rendering |
+| [`DynamicTrackCoverageWrapper.java`](https://github.com/debrief/debrief/blob/master/org.mwc.debrief.legacy/src/Debrief/Wrappers/DynamicTrackShapes/DynamicTrackCoverageWrapper.java) | Dynamic sensor coverage shape |


### PR DESCRIPTION
## Summary
Enhanced the SENSOR_DATA.md documentation by adding direct GitHub repository links to all referenced source files, classes, and methods. This improves documentation usability by allowing readers to quickly navigate to the actual implementation code.

## Key Changes
- **File references**: Converted plain file paths to clickable GitHub links pointing to the master branch
- **Class declarations**: Added links to specific class definition line numbers
- **Method documentation**: Added line number references and GitHub links for all key methods in tables
- **Field documentation**: Enhanced field tables with source line references and GitHub links
- **Inline references**: Added links to specific methods mentioned in prose sections (e.g., `getColor()`, `compareTo()`, `paint()`)
- **Cross-file references**: Added links to related classes in other files (e.g., TacticalDataWrapper, DynamicTrackCoverageWrapper)
- **Utility classes**: Added links to helper classes like FrequencyCalcs and StackedDotHelper

## Notable Implementation Details
- All links follow the pattern: `https://github.com/debrief/debrief/blob/master/[path]#L[line]`
- Table structures were enhanced with a new "Source" column containing line number links
- Both class-level and method-level links are provided for comprehensive navigation
- Links are provided for methods across multiple related classes (SensorContactWrapper, SensorWrapper, TacticalDataWrapper, Doublet, etc.)
- Documentation now covers the complete sensor data pipeline from import/export to rendering and analysis

This change makes the documentation more maintainable and developer-friendly by providing direct access to implementation details.

https://claude.ai/code/session_01P21uuBKa6xbFMNqboP9JEc