### PR TITLE
Fix/windows ease javadoc guard

### DIFF
--- a/org.mwc.debrief.help/collate_docbook.xml
+++ b/org.mwc.debrief.help/collate_docbook.xml
@@ -325,7 +325,21 @@
 		    -->
 	</target>
 	
-	<target name="ease_javadoc">
+	<target name="check_os">
+		<condition property="isUnixLike">
+			<or>
+				<os family="unix" />
+				<os family="mac" />
+			</or>
+		</condition>
+	</target>
+
+	<!-- The doclet call below relies on a hard-coded Linux classpath (/usr/share/ant/lib,
+	     /usr/lib/jvm), so it only works on unix-like hosts. Elsewhere it would delete
+	     org.mwc.debrief.scripting/help and then fail to regenerate it, leaving the
+	     scripting plugin unpackageable (its build.properties lists help/ in bin.includes).
+	     On those hosts we keep the committed help content instead. -->
+	<target name="ease_javadoc" depends="check_os" if="isUnixLike">
 		<delete dir="../org.mwc.debrief.scripting/help" />
         <exec executable="javadoc">
             <arg value="-classpath"/>

--- a/org.mwc.debrief.lite/build.xml
+++ b/org.mwc.debrief.lite/build.xml
@@ -102,7 +102,10 @@
 		<delete dir="${temp.folder}/debrief_lite.jar.bin"/>
 	</target>
 	
-	<target name="unitTests" depends="init">
+	<!-- skipped when the build is run with -DskipTests, which maven-antrun
+	     passes through as an Ant property. The Ant junit task below is not
+	     covered by surefire's own skipTests handling. -->
+	<target name="unitTests" depends="init" unless="skipTests">
 		<mkdir dir="${temp.folder}/reports"/>
 		<property name="report.dir" value="${temp.folder}/reports"/>
 				<path id="debrief_lite.test.classpath">


### PR DESCRIPTION
Updated build instructions, please fix for scripting builds on ms-windows.