### PR TITLE
docs: add draggable track point affordance spec artifacts

### DIFF
--- a/specs/002-drag-point-affordance/checklists/requirements.md
+++ b/specs/002-drag-point-affordance/checklists/requirements.md
@@ -14,13 +14,13 @@
 ## Requirement Completeness
 
 - [x] No [NEEDS CLARIFICATION] markers remain
-- [x] Requirements are testable and unambiguous
+- [x] Requirements are testable and unambiguous, including endpoint eligibility and marker appearance
 - [x] Success criteria are measurable
 - [x] Success criteria are technology-agnostic (no implementation details)
 - [x] All acceptance scenarios are defined
-- [x] Edge cases are identified
+- [x] Edge cases are identified, including hidden endpoints, closing segments, overlap, disposal, and multiple charts
 - [x] Scope is clearly bounded
-- [x] Dependencies and assumptions identified
+- [x] Dependencies and assumptions identified, including the absence of a separate lock state
 
 ## Feature Readiness
 
@@ -31,5 +31,8 @@
 
 ## Notes
 
-- Validation completed in 1 iteration; no outstanding quality issues.
+- Validation completed after resolving endpoint eligibility, marker visual treatment, per-chart lifecycle, and usability measurement gaps.
+- Marker definition: high-contrast outlined handle with contrasting center, minimum 8 screen pixels, with stronger hovered/dragging states.
+- Editability definition: existing Drag Component eligibility based on visible planning track, visible segment, and valid visible endpoint; no new lock state.
+- Measurement protocol is documented in `quickstart.md` for the quantitative success criteria.
 - Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/002-drag-point-affordance/checklists/requirements.md
+++ b/specs/002-drag-point-affordance/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Draggable Track Point Affordance
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed in 1 iteration; no outstanding quality issues.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/002-drag-point-affordance/contracts/drag-component-affordance.md
+++ b/specs/002-drag-point-affordance/contracts/drag-component-affordance.md
@@ -1,0 +1,53 @@
+# UI Contract: Drag Component Planning-Point Affordance
+
+**Date**: 2026-09-04
+**Spec**: [../spec.md](../spec.md)
+**Data Model**: [../data-model.md](../data-model.md)
+
+## Contract Scope
+
+Defines user-visible behavior for identifying draggable planning-track points while using Drag Component mode.
+
+## Preconditions
+
+1. A plot editor is open.
+2. A planning track is loaded and visible.
+3. Drag Component mode is active.
+
+## Inputs and Events
+
+| Event | Source | Contracted Behavior |
+|-------|--------|---------------------|
+| Mode activated (`DragComponent`) | User command/toolbar/shortcut | System evaluates current planning-track draggable endpoints and renders affordances. |
+| Mode deactivated (any other mode) | User command/toolbar/shortcut | System removes all drag-point affordances immediately on next repaint. |
+| Cursor moved | Mouse movement | Hovered endpoint state updates; cursor and marker emphasis stay synchronized. |
+| Drag started on endpoint | Mouse down + move | Existing drag preview/behavior starts; endpoint remains visually identified during drag. |
+| Drag committed | Mouse up | Drag action commits through existing undoable action flow; affordances refresh against new geometry. |
+| Track visibility/editability changed | Data/model update | Affordance set refreshes to include only currently draggable points. |
+| Zoom/pan changed | Viewport update | Affordances remain visible and correctly positioned for in-view draggable points. |
+
+## Output Guarantees
+
+1. Only points that are currently draggable on planning tracks are marked.
+2. Non-draggable points and non-planning-track points are not marked by this feature.
+3. Markers are visible enough to distinguish drag targets without requiring trial drag.
+4. Existing Drag Component behaviors (cursor changes, drag mechanics, undo/redo, recalculation) are preserved.
+5. Affordances never persist outside Drag Component mode.
+
+## Error and Edge Behavior
+
+- If no planning tracks are loaded, no affordances are shown and no error is raised.
+- If a track/segment becomes non-editable, associated affordances are removed in the next repaint cycle.
+- If endpoint conversion to screen coordinates fails (off-screen/invalid), marker is skipped for that frame.
+
+## Non-Functional Contract
+
+- Affordance changes are reflected by the next visible repaint after mode, pointer, or model state changes.
+- Affordance rendering must not introduce noticeable lag during normal planning-leg drag operations.
+
+## Acceptance Mapping
+
+- FR-001/FR-002/FR-007/FR-009: Marker presence is limited to valid draggable planning points.
+- FR-003/FR-006: Marker clarity and visibility support rapid recognition at normal zoom/pan levels.
+- FR-004/FR-005: Mode and editability transitions update affordance visibility.
+- FR-008: Drag execution semantics remain unchanged.

--- a/specs/002-drag-point-affordance/contracts/drag-component-affordance.md
+++ b/specs/002-drag-point-affordance/contracts/drag-component-affordance.md
@@ -6,48 +6,75 @@
 
 ## Contract Scope
 
-Defines user-visible behavior for identifying draggable planning-track points while using Drag Component mode.
+Defines user-visible behavior for identifying eligible planning-segment ends while using Drag Component mode.
+
+## Eligibility Contract
+
+An endpoint handle is rendered only when all conditions are true:
+
+1. Drag Component mode is active.
+2. The candidate belongs to a visible `CompositeTrackWrapper` planning track.
+3. The planning segment is visible.
+4. The segment has a valid last fix.
+5. The candidate follows the same endpoint eligibility predicate as the existing planning-track Drag Component hit test.
+
+The current model has no separate lock state. This feature does not add one. If a future editability rule prevents a candidate from being returned by the Drag Component hit-test path, the same rule must prevent its handle from being rendered.
+
+## Visual Contract
+
+- Each eligible endpoint has one centered endpoint handle.
+- The available handle is an outlined marker with a contrasting center, at least 8 screen pixels wide and high.
+- The marker must remain distinguishable against the planning track, map, and nearby labels without relying on color alone.
+- The hovered endpoint uses a stronger outline/fill treatment than available endpoints.
+- The actively dragged endpoint remains visually identified during drag preview and commit.
+- Handles must not add text labels or alter existing track labels.
+- If eligible endpoints are visually close or overlap, rendering must not change which candidate the existing nearest-hit logic selects.
 
 ## Preconditions
 
 1. A plot editor is open.
-2. A planning track is loaded and visible.
+2. A visible planning track is loaded.
 3. Drag Component mode is active.
 
 ## Inputs and Events
 
 | Event | Source | Contracted Behavior |
 |-------|--------|---------------------|
-| Mode activated (`DragComponent`) | User command/toolbar/shortcut | System evaluates current planning-track draggable endpoints and renders affordances. |
-| Mode deactivated (any other mode) | User command/toolbar/shortcut | System removes all drag-point affordances immediately on next repaint. |
-| Cursor moved | Mouse movement | Hovered endpoint state updates; cursor and marker emphasis stay synchronized. |
-| Drag started on endpoint | Mouse down + move | Existing drag preview/behavior starts; endpoint remains visually identified during drag. |
-| Drag committed | Mouse up | Drag action commits through existing undoable action flow; affordances refresh against new geometry. |
-| Track visibility/editability changed | Data/model update | Affordance set refreshes to include only currently draggable points. |
-| Zoom/pan changed | Viewport update | Affordances remain visible and correctly positioned for in-view draggable points. |
+| Mode activated (`DragComponent`) | User command, toolbar, or shortcut | Each chart evaluates eligible planning endpoints and renders handles. |
+| Mode deactivated (any other mode) | User command, toolbar, or shortcut | Each chart removes its handles and chart-local listeners/state. |
+| Cursor moved | Mouse movement | Existing nearest-hit logic determines the hovered candidate; its matching handle is emphasized. |
+| Drag started on endpoint | Mouse down and move | Existing drag preview and endpoint movement starts; no new hit tolerance is introduced. |
+| Drag committed | Mouse up | Existing undoable drag action commits; handles refresh from recalculated geometry. |
+| Track or segment visibility changes | Data/model update | Handles refresh to include only currently eligible endpoints. |
+| Endpoint geometry changes | Drag/recalculation/model update | Handles refresh from the latest world locations. |
+| Zoom or pan changes | Viewport update | Handles are projected again and remain aligned with in-view endpoints. |
+| Chart/canvas disposal | Workbench lifecycle | The chart releases its handle state/listeners without affecting other charts. |
 
 ## Output Guarantees
 
-1. Only points that are currently draggable on planning tracks are marked.
-2. Non-draggable points and non-planning-track points are not marked by this feature.
-3. Markers are visible enough to distinguish drag targets without requiring trial drag.
-4. Existing Drag Component behaviors (cursor changes, drag mechanics, undo/redo, recalculation) are preserved.
-5. Affordances never persist outside Drag Component mode.
+1. Every eligible visible planning-segment end has a corresponding handle in each active chart editor.
+2. Ordinary track points and non-planning plot elements are not marked by this feature.
+3. Hidden segments, invalid endpoints, and absent planning tracks produce no handles. The feature does not introduce a separate endpoint-visibility rule beyond the existing hit-test eligibility.
+4. Existing Drag Component behavior, including cursor transitions, hit tolerance, drag mechanics, course snapping, recalculation, undo, and redo, is preserved.
+5. Handles do not persist outside Drag Component mode or into REP/DPF data.
+6. Marker state in one chart cannot alter marker state, hover state, or disposal behavior in another chart.
 
 ## Error and Edge Behavior
 
-- If no planning tracks are loaded, no affordances are shown and no error is raised.
-- If a track/segment becomes non-editable, associated affordances are removed in the next repaint cycle.
-- If endpoint conversion to screen coordinates fails (off-screen/invalid), marker is skipped for that frame.
+- If no planning track is loaded, no handles are shown and no error is raised.
+- If a screen coordinate cannot be produced for an endpoint in the current frame, that handle is skipped for the frame.
+- If two candidates project to the same location, both remain eligible in the model and existing nearest-hit ordering remains authoritative; the renderer must not invent a new target.
+- If Drag Component is replaced while a drag is active, the old chart-local listener/state is released and the existing drag lifecycle is not left attached to the canvas.
 
 ## Non-Functional Contract
 
-- Affordance changes are reflected by the next visible repaint after mode, pointer, or model state changes.
-- Affordance rendering must not introduce noticeable lag during normal planning-leg drag operations.
+- Changes caused by mode, visibility, geometry, zoom, pan, or disposal are reflected by the next visible repaint or lifecycle update.
+- Handle rendering must not introduce noticeable lag during normal planning-leg drag operations.
+- The marker must remain discoverable at normal working zoom levels and in the supplied planning-track sample data.
 
 ## Acceptance Mapping
 
-- FR-001/FR-002/FR-007/FR-009: Marker presence is limited to valid draggable planning points.
-- FR-003/FR-006: Marker clarity and visibility support rapid recognition at normal zoom/pan levels.
-- FR-004/FR-005: Mode and editability transitions update affordance visibility.
-- FR-008: Drag execution semantics remain unchanged.
+- FR-001/FR-002/FR-005/FR-007/FR-009: Eligibility and marker presence are limited to valid planning endpoints.
+- FR-003: Available, hovered, and dragging visual states are distinct.
+- FR-004/FR-006: Mode and viewport/model transitions update marker visibility and positions.
+- FR-008: Existing drag execution semantics remain unchanged.

--- a/specs/002-drag-point-affordance/data-model.md
+++ b/specs/002-drag-point-affordance/data-model.md
@@ -1,0 +1,99 @@
+# Data Model: Draggable Track Point Affordance
+
+**Date**: 2026-09-04
+**Spec**: [spec.md](./spec.md)
+
+## Entities
+
+### 1) PlanningTrack
+
+- Purpose: User-created planning track made of ordered planning legs.
+- Backing type: `Debrief.Wrappers.CompositeTrackWrapper`.
+- Key fields:
+  - `name`
+  - `visible`
+  - `segments` (ordered list of `PlanningSegment`)
+  - `origin` and `startDate` (used during recalc)
+- Validation rules:
+  - Affordances are eligible only when track is visible and currently editable.
+  - No affordance must be shown when no planning track is available.
+
+### 2) PlanningSegment
+
+- Purpose: One leg inside a planning track with computed fixes.
+- Backing type: `Debrief.Wrappers.Track.PlanningSegment`.
+- Key fields:
+  - `course`
+  - `speed`
+  - `distance`
+  - `duration`
+  - `depth`
+  - `visible`
+  - `firstFix` and `lastFix`
+- Validation rules:
+  - Draggable endpoint is the segment `lastFix` location used by existing hotspot logic.
+  - Hidden/non-editable segments must not produce draggable affordances.
+
+### 3) DraggableEndpointCandidate
+
+- Purpose: Runtime representation of one planning-segment point that can be dragged.
+- Backing source: Derived from existing hotspot logic in `CompositeTrackWrapper.findNearestHotSpotIn(...)`.
+- Key fields:
+  - `parentTrack` (PlanningTrack reference)
+  - `parentSegment` (PlanningSegment reference)
+  - `worldLocation` (drag-target location)
+  - `isDraggable` (true only when current mode and editability permit)
+- Validation rules:
+  - Candidate set includes only points that can be dragged now.
+  - Candidate identity must stay aligned with the object used by drag apply/undo.
+
+### 4) DragAffordanceMarker
+
+- Purpose: Visual indicator rendered for a draggable endpoint.
+- Lifecycle: Runtime-only; not persisted.
+- Key fields:
+  - `endpoint` (DraggableEndpointCandidate reference)
+  - `screenPoint`
+  - `visualState` (`available`, `hovered`, `dragging`)
+  - `visible`
+- Validation rules:
+  - Markers appear only while Drag Component mode is active.
+  - Non-draggable points never receive markers.
+  - Marker updates must track zoom/pan and mode changes.
+
+### 5) DragComponentInteractionState
+
+- Purpose: Runtime state of Drag Component interaction and rendering.
+- Backing type: `DragComponent.DragComponentMode`.
+- Key fields:
+  - `modeActive`
+  - `hoverTarget`
+  - `hoverComponent`
+  - `isDragging`
+  - `lastPointerPosition`
+- Validation rules:
+  - Entering/exiting mode toggles affordance visibility consistently.
+  - Drag commit must preserve existing undo/redo behavior.
+
+## Relationships
+
+- One `PlanningTrack` has many `PlanningSegment` entries.
+- Each `PlanningSegment` contributes zero or one current `DraggableEndpointCandidate`.
+- Each `DraggableEndpointCandidate` maps to zero or one visible `DragAffordanceMarker` at any repaint.
+- `DragComponentInteractionState` controls whether markers are rendered and which marker is in `hovered` or `dragging` state.
+
+## State Transitions
+
+| State | Trigger | Next State | Expected Result |
+|-------|---------|------------|-----------------|
+| Inactive | User activates Drag Component | Armed | Draggable markers become visible for eligible planning points. |
+| Armed | Pointer enters draggable endpoint hit zone | Hovered | Hover feedback updates cursor and marker emphasis. |
+| Hovered | Mouse down and drag begins | Dragging | Existing drag preview/movement begins for selected endpoint. |
+| Dragging | Mouse up (commit) | Armed | Drag action committed; markers refresh for recalculated geometry. |
+| Armed/Hovered/Dragging | User leaves Drag Component mode | Inactive | All draggable-point affordances are removed. |
+
+## Derived Data and Invariants
+
+- Draggable affordance visibility is derived from `(modeActive AND endpoint.isDraggable AND endpoint is visible in viewport)`.
+- Marker rendering does not modify planning-track persistence data.
+- Affordance presence must not alter drag targeting, course snapping, or recalc outputs.

--- a/specs/002-drag-point-affordance/data-model.md
+++ b/specs/002-drag-point-affordance/data-model.md
@@ -3,97 +3,105 @@
 **Date**: 2026-09-04
 **Spec**: [spec.md](./spec.md)
 
-## Entities
+## Existing Domain Entities
 
 ### 1) PlanningTrack
 
 - Purpose: User-created planning track made of ordered planning legs.
 - Backing type: `Debrief.Wrappers.CompositeTrackWrapper`.
-- Key fields:
-  - `name`
+- Key fields and behavior:
   - `visible`
-  - `segments` (ordered list of `PlanningSegment`)
-  - `origin` and `startDate` (used during recalc)
-- Validation rules:
-  - Affordances are eligible only when track is visible and currently editable.
-  - No affordance must be shown when no planning track is available.
+  - Ordered `PlanningSegment` children
+  - `origin` and `startDate` used during recalculation
+- Eligibility rules:
+  - The track must be visible.
+  - The track must be traversed by the existing Drag Component hit-test path.
+  - No separate persisted lock state is introduced by this feature.
 
 ### 2) PlanningSegment
 
 - Purpose: One leg inside a planning track with computed fixes.
 - Backing type: `Debrief.Wrappers.Track.PlanningSegment`.
-- Key fields:
-  - `course`
-  - `speed`
-  - `distance`
-  - `duration`
-  - `depth`
+- Key fields and behavior:
   - `visible`
-  - `firstFix` and `lastFix`
-- Validation rules:
-  - Draggable endpoint is the segment `lastFix` location used by existing hotspot logic.
-  - Hidden/non-editable segments must not produce draggable affordances.
+  - Ordered fixes, including `firstFix` and `lastFix`
+  - Course, speed, distance, duration, and depth used to recalculate the leg
+- Eligibility rules:
+  - The segment must be visible.
+  - The segment must have a valid last fix.
+  - The endpoint must be projectable in the current chart to be rendered in that frame.
+  - Closing segments follow the same rule as other planning segments.
+
+## Runtime Derived Entities
 
 ### 3) DraggableEndpointCandidate
 
-- Purpose: Runtime representation of one planning-segment point that can be dragged.
-- Backing source: Derived from existing hotspot logic in `CompositeTrackWrapper.findNearestHotSpotIn(...)`.
+- Purpose: Runtime representation of one planning-segment end that the Drag Component can target.
+- Backing source: A new non-cursor-dependent enumeration helper in `CompositeTrackWrapper`, sharing eligibility with `findNearestHotSpotIn(...)`.
 - Key fields:
-  - `parentTrack` (PlanningTrack reference)
-  - `parentSegment` (PlanningSegment reference)
-  - `worldLocation` (drag-target location)
-  - `isDraggable` (true only when current mode and editability permit)
-- Validation rules:
-  - Candidate set includes only points that can be dragged now.
-  - Candidate identity must stay aligned with the object used by drag apply/undo.
+  - `parentTrack`: `CompositeTrackWrapper`
+  - `parentSegment`: `PlanningSegment`
+  - `worldLocation`: endpoint location used by the existing `shift(WorldLocation, WorldVector)` path
+  - `eligible`: derived from current visibility and valid-endpoint rules
+- Invariants:
+  - Candidate identity must remain aligned with the object used by drag apply and undo.
+  - Candidates are not persisted.
+  - Ordinary tracks and unrelated plottables are not candidates for this feature.
 
 ### 4) DragAffordanceMarker
 
-- Purpose: Visual indicator rendered for a draggable endpoint.
-- Lifecycle: Runtime-only; not persisted.
+- Purpose: Runtime visual handle for one eligible endpoint.
+- Lifecycle: Created and rendered per chart editor; never persisted.
 - Key fields:
-  - `endpoint` (DraggableEndpointCandidate reference)
-  - `screenPoint`
-  - `visualState` (`available`, `hovered`, `dragging`)
+  - `candidate`
+  - `screenPoint`, derived from the chart projection during repaint
+  - `visualState`: `available`, `hovered`, or `dragging`
   - `visible`
-- Validation rules:
-  - Markers appear only while Drag Component mode is active.
-  - Non-draggable points never receive markers.
-  - Marker updates must track zoom/pan and mode changes.
+- Visual invariants:
+  - Available markers use a high-contrast outline with a contrasting center.
+  - The marker is at least 8 screen pixels wide and high.
+  - Hovered and dragging markers use a stronger visual treatment.
+  - Marker meaning does not rely on color alone.
 
-### 5) DragComponentInteractionState
+### 5) DragComponentChartState
 
-- Purpose: Runtime state of Drag Component interaction and rendering.
-- Backing type: `DragComponent.DragComponentMode`.
+- Purpose: Per-chart runtime state for Drag Component interaction and affordance rendering.
+- Backing behavior: Owned by the chart-specific mode/overlay lifecycle associated with `DragComponent.DragComponentMode`.
 - Key fields:
+  - `chart`
+  - `canvas`
   - `modeActive`
+  - `eligibleCandidates`
   - `hoverTarget`
   - `hoverComponent`
   - `isDragging`
-  - `lastPointerPosition`
-- Validation rules:
-  - Entering/exiting mode toggles affordance visibility consistently.
-  - Drag commit must preserve existing undo/redo behavior.
+  - `paintListener` or equivalent repaint registration
+- Invariants:
+  - State is not shared between chart editors.
+  - State is cleared when the mode is replaced or the chart/canvas is disposed.
+  - A chart with no planning track has no markers.
 
 ## Relationships
 
 - One `PlanningTrack` has many `PlanningSegment` entries.
-- Each `PlanningSegment` contributes zero or one current `DraggableEndpointCandidate`.
-- Each `DraggableEndpointCandidate` maps to zero or one visible `DragAffordanceMarker` at any repaint.
-- `DragComponentInteractionState` controls whether markers are rendered and which marker is in `hovered` or `dragging` state.
+- Each eligible `PlanningSegment` contributes one `DraggableEndpointCandidate` for its last fix.
+- Each candidate maps to one marker per active chart editor, unless its screen coordinate is unavailable for the current frame.
+- `DragComponentChartState` controls marker rendering and hover/drag visual states for one chart.
 
 ## State Transitions
 
 | State | Trigger | Next State | Expected Result |
 |-------|---------|------------|-----------------|
-| Inactive | User activates Drag Component | Armed | Draggable markers become visible for eligible planning points. |
-| Armed | Pointer enters draggable endpoint hit zone | Hovered | Hover feedback updates cursor and marker emphasis. |
-| Hovered | Mouse down and drag begins | Dragging | Existing drag preview/movement begins for selected endpoint. |
-| Dragging | Mouse up (commit) | Armed | Drag action committed; markers refresh for recalculated geometry. |
-| Armed/Hovered/Dragging | User leaves Drag Component mode | Inactive | All draggable-point affordances are removed. |
+| Inactive | User activates Drag Component | Armed | Each chart builds current eligible candidates and renders endpoint handles. |
+| Armed | Pointer enters an eligible endpoint hit zone | Hovered | Existing hit cursor is shown and the matching handle is emphasized. |
+| Hovered | Mouse down and drag begins | Dragging | Existing drag preview and endpoint movement begin. |
+| Dragging | Mouse up (commit) | Armed | Existing undoable action commits and markers refresh from current geometry. |
+| Armed/Hovered/Dragging | User leaves Drag Component mode | Inactive | Handles and per-chart listeners/state are removed. |
+| Any active state | Chart/canvas disposed | Disposed | Listeners and chart-local marker state are released without affecting other charts. |
 
 ## Derived Data and Invariants
 
-- Draggable affordance visibility is derived from `(modeActive AND endpoint.isDraggable AND endpoint is visible in viewport)`.
+- Marker visibility is derived from `(Drag Component active AND planning track visible AND segment visible AND valid last fix AND projectable in current chart frame)`.
+- Screen coordinates are derived at render time from the current chart projection.
 - Marker rendering does not modify planning-track persistence data.
-- Affordance presence must not alter drag targeting, course snapping, or recalc outputs.
+- Affordance presence must not alter hit tolerance, candidate selection, course snapping, recalculation, undo, or redo.

--- a/specs/002-drag-point-affordance/plan.md
+++ b/specs/002-drag-point-affordance/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Draggable Track Point Affordance
+
+**Branch**: `002-drag-point-affordance` | **Date**: 2026-09-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-drag-point-affordance/spec.md`
+
+## Summary
+
+Add a clear visual affordance for draggable planning-track points when the Drag Component tool is active, so users can quickly identify valid drag targets before interacting. The implementation will reuse existing planning-leg hotspot discovery and drag mechanics, adding a mode-scoped rendering layer for affordance markers without changing file formats or core drag semantics.
+
+## Technical Context
+
+**Language/Version**: Java 11 (Tycho-built Eclipse RCP plugins)  
+**Primary Dependencies**: `org.mwc.debrief.core` drag actions, `org.mwc.debrief.legacy` planning-track wrappers, `org.mwc.cmap.plotViewer` SWT chart canvas and drag mode lifecycle  
+**Storage**: Existing in-memory track model with current REP/DPF persistence; no storage schema changes  
+**Testing**: Tycho JUnit suites (`org.mwc.debrief.test2`), RCPTT UI suites (`org.mwc.debrief.ui_test`), plus manual scenario validation with sample planning tracks  
+**Target Platform**: Desktop Eclipse RCP application (Windows/Linux/macOS)  
+**Project Type**: Multi-module desktop rich-client application (plugin architecture)  
+**Performance Goals**: Affordance visibility updates by next repaint during mode/hover/view changes and no perceptible slowdown during standard planning-leg dragging  
+**Constraints**: Show affordances only for actually draggable planning-track points, only in Drag Component mode, preserve undo/redo and planning-leg recalculation behavior  
+**Scale/Scope**: Planning charts with many visible legs (targeting normal analyst workloads) and synchronized mode behavior across open chart editors
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Scope note: `.specify/memory/constitution.md` governs this repository's documentation work. For this product feature plan, principles are applied to planning rigor, evidence quality, and scope control.
+
+### Pre-Phase 0 Gate Review
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Navigability Over Comprehensiveness | PASS | Plan and artifacts point to exact modules and methods that control draggable planning points. |
+| II. Signal Over Ceremony | PASS | Deliverables focus on actionable behavior and acceptance expectations. |
+| III. Logic and Algorithms Are Primary | PASS | Work is centered on existing drag logic and spatial rendering behavior, not generic UI boilerplate. |
+| IV. Explore Before Asking | PASS | Code inspection completed for drag mode flow, hotspot discovery, and planning segment handling. |
+| V. Document What Is, Not What Should Be | PASS | Design reuses existing drag contracts and only adds affordance signaling around current behavior. |
+
+### Post-Phase 1 Gate Re-Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Navigability Over Comprehensiveness | PASS | `research.md`, `data-model.md`, `quickstart.md`, and `contracts/` link implementation touchpoints and validation paths. |
+| II. Signal Over Ceremony | PASS | Contract and validation steps remain concise and test-focused. |
+| III. Logic and Algorithms Are Primary | PASS | Design preserves existing planning-leg drag mechanics and course recalculation logic. |
+| IV. Explore Before Asking | PASS | No unresolved clarifications remain after repository research. |
+| V. Document What Is, Not What Should Be | PASS | Proposed behavior is bounded to measurable affordance outcomes from the approved spec. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-drag-point-affordance/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── drag-component-affordance.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+org.mwc.debrief.core/
+└── src/org/mwc/debrief/core/actions/
+    └── DragComponent.java            # Drag mode lifecycle and drag-component hover/paint behavior
+
+org.mwc.debrief.legacy/
+└── src/Debrief/Wrappers/
+    ├── CompositeTrackWrapper.java    # Planning-leg draggable endpoint discovery
+    └── Track/PlanningSegment.java    # Planning-leg endpoint semantics and recalc context
+
+org.mwc.cmap.legacy/
+└── src/MWC/GUI/Shapes/
+    └── HasDraggableComponents.java   # Draggable component contract (reference for compatibility)
+
+org.mwc.debrief.ui_test/
+└── test-cases/                       # Optional UI automation extension for affordance validation
+
+org.mwc.debrief.test2/
+└── src/org/mwc/debrief/test/
+    └── AllTests.java                 # Existing suite used for regression confidence
+```
+
+**Structure Decision**: Implement within existing drag action and planning wrapper modules to keep behavior close to current hotspot detection and drag execution paths, with optional UI automation additions in the existing RCPTT test area.
+
+## Complexity Tracking
+
+No constitution violations requiring mitigation.

--- a/specs/002-drag-point-affordance/plan.md
+++ b/specs/002-drag-point-affordance/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Add a clear visual affordance for draggable planning-track points when the Drag Component tool is active, so users can quickly identify valid drag targets before interacting. The implementation will reuse existing planning-leg hotspot discovery and drag mechanics, adding a mode-scoped rendering layer for affordance markers without changing file formats or core drag semantics.
+Add a high-contrast endpoint handle for each eligible visible planning-segment end when the Drag Component tool is active, so users can identify valid drag targets before interacting. The implementation will share endpoint eligibility with existing planning-leg hotspot discovery, add a mode-scoped rendering layer, and keep marker state local to each chart editor without changing file formats or core drag semantics.
 
 ## Technical Context
 
@@ -16,7 +16,7 @@ Add a clear visual affordance for draggable planning-track points when the Drag 
 **Target Platform**: Desktop Eclipse RCP application (Windows/Linux/macOS)  
 **Project Type**: Multi-module desktop rich-client application (plugin architecture)  
 **Performance Goals**: Affordance visibility updates by next repaint during mode/hover/view changes and no perceptible slowdown during standard planning-leg dragging  
-**Constraints**: Show affordances only for actually draggable planning-track points, only in Drag Component mode, preserve undo/redo and planning-leg recalculation behavior  
+**Constraints**: Show handles only for visible planning-segment ends eligible under the existing Drag Component hit-test rules, only in Drag Component mode, preserve hit tolerance/undo/redo/recalculation, and avoid shared mutable marker state across chart editors
 **Scale/Scope**: Planning charts with many visible legs (targeting normal analyst workloads) and synchronized mode behavior across open chart editors
 
 ## Constitution Check
@@ -31,9 +31,9 @@ Scope note: `.specify/memory/constitution.md` governs this repository's document
 |-----------|--------|-------|
 | I. Navigability Over Comprehensiveness | PASS | Plan and artifacts point to exact modules and methods that control draggable planning points. |
 | II. Signal Over Ceremony | PASS | Deliverables focus on actionable behavior and acceptance expectations. |
-| III. Logic and Algorithms Are Primary | PASS | Work is centered on existing drag logic and spatial rendering behavior, not generic UI boilerplate. |
+| III. Logic and Algorithms Are Primary | PASS | Work is centered on existing drag eligibility and spatial rendering behavior, not generic UI boilerplate. |
 | IV. Explore Before Asking | PASS | Code inspection completed for drag mode flow, hotspot discovery, and planning segment handling. |
-| V. Document What Is, Not What Should Be | PASS | Design reuses existing drag contracts and only adds affordance signaling around current behavior. |
+| V. Document What Is, Not What Should Be | PASS | Existing endpoint and visibility behavior is recorded; the new handle is explicitly bounded as proposed behavior. |
 
 ### Post-Phase 1 Gate Re-Check
 
@@ -41,9 +41,9 @@ Scope note: `.specify/memory/constitution.md` governs this repository's document
 |-----------|--------|-------|
 | I. Navigability Over Comprehensiveness | PASS | `research.md`, `data-model.md`, `quickstart.md`, and `contracts/` link implementation touchpoints and validation paths. |
 | II. Signal Over Ceremony | PASS | Contract and validation steps remain concise and test-focused. |
-| III. Logic and Algorithms Are Primary | PASS | Design preserves existing planning-leg drag mechanics and course recalculation logic. |
-| IV. Explore Before Asking | PASS | No unresolved clarifications remain after repository research. |
-| V. Document What Is, Not What Should Be | PASS | Proposed behavior is bounded to measurable affordance outcomes from the approved spec. |
+| III. Logic and Algorithms Are Primary | PASS | Design preserves existing planning-leg hit testing, course recalculation, and drag mechanics while adding a spatial marker layer. |
+| IV. Explore Before Asking | PASS | Eligibility, marker appearance, endpoint scope, and per-editor lifecycle are resolved from code inspection and explicit design decisions. |
+| V. Document What Is, Not What Should Be | PASS | Existing behavior is separated from proposed handle rendering; no unsupported lock model is assumed. |
 
 ## Project Structure
 
@@ -65,7 +65,8 @@ specs/002-drag-point-affordance/
 ```text
 org.mwc.debrief.core/
 └── src/org/mwc/debrief/core/actions/
-    └── DragComponent.java            # Drag mode lifecycle and drag-component hover/paint behavior
+    ├── DragComponent.java            # Drag mode, endpoint handles, and hover/drag paint behavior
+    └── drag/CoreDragOperation.java   # Existing drag-operation base; preserve lifecycle assumptions
 
 org.mwc.debrief.legacy/
 └── src/Debrief/Wrappers/
@@ -76,6 +77,11 @@ org.mwc.cmap.legacy/
 └── src/MWC/GUI/Shapes/
     └── HasDraggableComponents.java   # Draggable component contract (reference for compatibility)
 
+org.mwc.cmap.plotViewer/
+└── src/org/mwc/cmap/plotViewer/
+    ├── actions/CoreDragAction.java   # Shared mode switch; must not share marker state between charts
+    └── editors/chart/SWTChart.java   # Chart mode assignment and repaint lifecycle
+
 org.mwc.debrief.ui_test/
 └── test-cases/                       # Optional UI automation extension for affordance validation
 
@@ -84,7 +90,7 @@ org.mwc.debrief.test2/
     └── AllTests.java                 # Existing suite used for regression confidence
 ```
 
-**Structure Decision**: Implement within existing drag action and planning wrapper modules to keep behavior close to current hotspot detection and drag execution paths, with optional UI automation additions in the existing RCPTT test area.
+**Structure Decision**: Add a planning-endpoint enumeration path beside the existing nearest-endpoint hit test, reuse the same eligibility predicate for both paths, and render handles through per-chart Drag Component state. Update shared mode switching only as needed to guarantee per-editor ownership. Add UI automation only for observable lifecycle behavior; keep exact marker geometry and eligibility checks covered by manual/automated validation close to the owning modules.
 
 ## Complexity Tracking
 

--- a/specs/002-drag-point-affordance/quickstart.md
+++ b/specs/002-drag-point-affordance/quickstart.md
@@ -1,0 +1,88 @@
+# Quickstart: Validate Draggable Planning-Point Affordance
+
+**Date**: 2026-09-04
+**Spec**: [spec.md](./spec.md)
+**Contract**: [contracts/drag-component-affordance.md](./contracts/drag-component-affordance.md)
+**Data Model**: [data-model.md](./data-model.md)
+
+## Prerequisites
+
+- Java 11 and Maven available.
+- Debrief workspace builds successfully.
+- Sample planning datasets available under `org.mwc.cmap.combined.feature/root_installs/sample_data/`.
+
+## Setup Commands
+
+```bash
+mvn test -pl org.mwc.debrief.test2
+mvn clean install -pl org.mwc.debrief.product -am -DskipTests
+```
+
+Optional UI automation baseline:
+
+```bash
+mvn -f org.mwc.debrief.ui_test/pom.xml test
+```
+
+Optional sample data sanity checks:
+
+```bash
+rg -n "PLANNING_ORIGIN|PLANNING_RANGE_SPEED|PLANNING_SPEED_TIME" org.mwc.cmap.combined.feature/root_installs/sample_data/planning_tracks.rep
+rg -n "<composite_track|<planning_segment" org.mwc.cmap.combined.feature/root_installs/sample_data/compositeTrack.dpf
+```
+
+## Manual Validation Scenarios
+
+Use either `planning_tracks.rep` or `Demo/TrialsPlanning/TrialsPlanning3.dpf` from the sample data folder.
+
+### Scenario 1: Affordance appears only in Drag Component mode
+
+1. Open plot editor with planning track data loaded.
+2. Switch to a non-drag-component mode.
+3. Verify no draggable-point affordances are shown.
+4. Activate Drag Component (toolbar item or shortcut).
+5. Verify draggable planning points become visibly marked.
+
+Expected result:
+- Matches contract preconditions and output guarantees 1, 2, and 5.
+
+### Scenario 2: Users can identify the correct drag target before dragging
+
+1. With Drag Component active, inspect a planning track with multiple legs.
+2. Identify a marked draggable endpoint.
+3. Start drag on that endpoint and adjust leg geometry.
+
+Expected result:
+- Marked endpoint is the point that drags.
+- Drag behavior remains normal and leg recalculation occurs as before.
+
+### Scenario 3: Non-draggable elements are not mis-signaled
+
+1. Keep Drag Component active.
+2. Attempt to locate affordances on non-planning-track points or non-draggable points.
+
+Expected result:
+- No false affordances appear on unsupported points.
+
+### Scenario 4: Affordance stability during zoom and pan
+
+1. With Drag Component active, zoom in/out and pan across the planning track.
+2. Verify in-view draggable endpoints remain marked and visually distinct.
+
+Expected result:
+- Marker positions stay aligned with draggable points and remain visible enough for recognition.
+
+### Scenario 5: Undo/redo and mode transitions
+
+1. Drag a planning-leg endpoint and commit.
+2. Run undo, then redo.
+3. Switch away from Drag Component and back again.
+
+Expected result:
+- Undo/redo behavior is unchanged.
+- Affordances disappear outside mode and reappear when mode is reactivated.
+
+## Completion Criteria
+
+- All scenarios pass without regressions to existing drag behavior.
+- Observed behavior satisfies `contracts/drag-component-affordance.md` and FR-001 through FR-009 in `spec.md`.

--- a/specs/002-drag-point-affordance/quickstart.md
+++ b/specs/002-drag-point-affordance/quickstart.md
@@ -10,6 +10,7 @@
 - Java 11 and Maven available.
 - Debrief workspace builds successfully.
 - Sample planning datasets available under `org.mwc.cmap.combined.feature/root_installs/sample_data/`.
+- A product build or Eclipse launch configuration capable of opening a plot editor.
 
 ## Setup Commands
 
@@ -33,56 +34,77 @@ rg -n "<composite_track|<planning_segment" org.mwc.cmap.combined.feature/root_in
 
 ## Manual Validation Scenarios
 
-Use either `planning_tracks.rep` or `Demo/TrialsPlanning/TrialsPlanning3.dpf` from the sample data folder.
+Use `planning_tracks.rep` or `Demo/TrialsPlanning/TrialsPlanning3.dpf` from the sample data folder. Record the build identifier and the dataset used for each run.
 
-### Scenario 1: Affordance appears only in Drag Component mode
+### Scenario 1: Handles appear for eligible planning endpoints
 
-1. Open plot editor with planning track data loaded.
-2. Switch to a non-drag-component mode.
-3. Verify no draggable-point affordances are shown.
-4. Activate Drag Component (toolbar item or shortcut).
-5. Verify draggable planning points become visibly marked.
-
-Expected result:
-- Matches contract preconditions and output guarantees 1, 2, and 5.
-
-### Scenario 2: Users can identify the correct drag target before dragging
-
-1. With Drag Component active, inspect a planning track with multiple legs.
-2. Identify a marked draggable endpoint.
-3. Start drag on that endpoint and adjust leg geometry.
+1. Open the selected planning dataset in a plot editor.
+2. Identify the visible planning segments and their visible last fixes.
+3. Switch to a non-Drag-Component mode and verify no endpoint handles are shown.
+4. Activate Drag Component from the toolbar or shortcut.
+5. Verify that each visible planning-segment end has one high-contrast outlined handle with a contrasting center, at least 8 screen pixels wide and high.
+6. Verify ordinary track points and non-planning plot elements have no handle.
 
 Expected result:
-- Marked endpoint is the point that drags.
-- Drag behavior remains normal and leg recalculation occurs as before.
+- Matches the eligibility and visual contracts.
 
-### Scenario 3: Non-draggable elements are not mis-signaled
+### Scenario 2: Handle maps to the existing drag behavior
 
-1. Keep Drag Component active.
-2. Attempt to locate affordances on non-planning-track points or non-draggable points.
-
-Expected result:
-- No false affordances appear on unsupported points.
-
-### Scenario 4: Affordance stability during zoom and pan
-
-1. With Drag Component active, zoom in/out and pan across the planning track.
-2. Verify in-view draggable endpoints remain marked and visually distinct.
+1. With Drag Component active, choose a marked planning-segment end.
+2. Hover it and verify the existing point-hit cursor appears and the handle becomes emphasized.
+3. Drag it to a new bearing and release.
+4. Verify the planning leg recalculates as it did before the feature.
+5. Verify undo and redo still reverse and reapply the same drag.
 
 Expected result:
-- Marker positions stay aligned with draggable points and remain visible enough for recognition.
+- The handle improves recognition without changing target selection, hit tolerance, course snapping, recalculation, undo, or redo.
 
-### Scenario 5: Undo/redo and mode transitions
+### Scenario 3: Visibility and endpoint edge cases
 
-1. Drag a planning-leg endpoint and commit.
-2. Run undo, then redo.
-3. Switch away from Drag Component and back again.
+1. Hide a planning segment and verify its handle disappears.
+2. Hide an endpoint fix, if the UI/data path supports this state, and verify its handle is absent.
+3. Open a dataset containing a closing segment and verify its endpoint follows the same rule as other planning segments.
+4. Load a plot with no planning track and verify no handles are shown.
 
 Expected result:
-- Undo/redo behavior is unchanged.
-- Affordances disappear outside mode and reappear when mode is reactivated.
+- No handle implies drag availability for hidden, invalid, or absent candidates.
+
+### Scenario 4: Zoom, pan, overlap, and mode transitions
+
+1. With Drag Component active, zoom in and out across the planning track.
+2. Pan across the track and verify handles remain centered on current endpoint locations.
+3. Inspect closely spaced or overlapping endpoints. Verify handles do not alter which endpoint the existing nearest-hit logic selects.
+4. Switch rapidly between Drag Component and another tool several times.
+5. Verify handles disappear outside Drag Component and do not remain after a chart is closed.
+
+Expected result:
+- Handles track current projection and lifecycle state without stale overlays or cross-chart leakage.
+
+### Scenario 5: Multiple chart editors
+
+1. Open the same or different planning datasets in two chart editors.
+2. Activate Drag Component and confirm both editors show their own eligible handles.
+3. Hover or drag an endpoint in one editor.
+4. Verify the other editor's marker positions, hover state, and data remain independent.
+5. Close one editor and confirm the remaining editor continues to render and interact normally.
+
+Expected result:
+- Marker state and cleanup are local to each chart editor.
+
+## Usability Measurement Protocol
+
+Use the current build as the baseline and the feature build as the comparison. Use the same dataset, task order, and instructions for both builds where practical.
+
+- Recruit at least 5 analysts or representative users.
+- Give each participant 10 representative planning-leg edit tasks.
+- For each task, record time from Drag Component activation to the first correct drag.
+- Count attempts to drag an unsupported point before the first correct drag.
+- Ask each participant to rate endpoint discoverability from 1 (very unclear) to 5 (very clear).
+- Report the median time, unsupported-target attempt rate, percentage identifying a handle within 5 seconds, and percentage rating discoverability 4 or 5.
 
 ## Completion Criteria
 
-- All scenarios pass without regressions to existing drag behavior.
-- Observed behavior satisfies `contracts/drag-component-affordance.md` and FR-001 through FR-009 in `spec.md`.
+- All manual scenarios pass without regressions to existing drag behavior.
+- The sample-data run confirms 100% of eligible visible endpoints are marked and no ineligible elements are marked.
+- The usability results can be compared with the current-build baseline and evaluated against SC-001 through SC-004 in `spec.md`.
+- Observed behavior satisfies `contracts/drag-component-affordance.md`.

--- a/specs/002-drag-point-affordance/research.md
+++ b/specs/002-drag-point-affordance/research.md
@@ -5,62 +5,81 @@
 
 ## Research Outcomes
 
-### Decision 1: Scope affordances to planning-track draggable endpoints only
+### Decision 1: Scope affordances to visible planning-segment ends only
 
-- Decision: Show affordances only for draggable points exposed by planning tracks when Drag Component mode is active.
-- Rationale: User need is to identify draggable planning-leg points; broader scope risks signaling drag support where none exists.
+- Decision: Show one endpoint handle for each visible planning segment with a valid last fix when Drag Component mode is active; skip the handle for a frame if the current chart cannot project its location.
+- Rationale: The current planning hotspot path uses each visible segment's last fix as the drag component. Broader point coverage would signal targets that the tool does not currently expose, while adding a new fix-visibility rule could change existing drag behavior.
 - Alternatives considered:
   - Show affordances for all track points in all drag modes (rejected: high false-positive risk).
   - Show affordances only after hover (rejected: does not solve pre-hover discoverability).
+  - Add a separate lock/editability model (rejected: no such model exists in the current planning-track data and it is outside this feature scope).
 
-### Decision 2: Reuse existing hotspot source of truth
+### Decision 2: Share eligibility, add enumeration
 
-- Decision: Use existing draggable hotspot generation from `Debrief.Wrappers.CompositeTrackWrapper.findNearestHotSpotIn(...)` as the source of draggable endpoints.
-- Rationale: This method already defines which planning-leg endpoints are draggable and how drag updates propagate to segment course/recalculation.
+- Decision: Add a non-cursor-dependent endpoint enumeration helper in `CompositeTrackWrapper`, and make the existing nearest-hotspot path use the same endpoint/visibility predicate where practical.
+- Rationale: `findNearestHotSpotIn(...)` is cursor-dependent and returns only the nearest candidate. It is authoritative for current drag semantics, but cannot by itself render all handles. Sharing the eligibility predicate prevents the marker list and hit test from drifting.
 - Alternatives considered:
-  - Derive draggable points from all visible fixes (rejected: not equivalent to true drag targets).
-  - Maintain a parallel draggable index (rejected: duplicate logic and drift risk).
+  - Derive draggable points from all fixes (rejected: not equivalent to true drag targets).
+  - Maintain a separate parallel eligibility implementation (rejected: duplicate logic and drift risk).
 
-### Decision 3: Render affordances as mode-scoped overlay, not persisted model data
+### Decision 3: Render affordances as mode-scoped, non-persisted handles
 
-- Decision: Render draggable-point affordances in Drag Component mode via chart repaint/overlay behavior rather than adding persistent entities to planning-track data.
+- Decision: Render endpoint handles in Drag Component mode through chart repaint/overlay behavior rather than adding persistent entities to planning-track data.
 - Rationale: Affordance is interaction state, not domain state; this avoids file format and model persistence impact.
 - Alternatives considered:
-  - Add new flags/attributes to planning segments (rejected: unnecessary persistence coupling).
+  - Add new flags or attributes to planning segments (rejected: unnecessary persistence coupling).
   - Always paint affordances from track rendering code (rejected: cannot respect active tool state cleanly).
 
-### Decision 4: Keep hit testing and drag mechanics unchanged
+### Decision 4: Use a concrete endpoint handle visual
 
-- Decision: Preserve existing jitter threshold checks, cursor transitions, drag action creation, undo/redo, and planning-leg recalc behavior.
-- Rationale: Requirement FR-008 requires no regression in existing drag behavior.
+- Decision: Render a high-contrast outlined endpoint handle with a contrasting center, at least 8 screen pixels in both dimensions. Use a stronger outline/fill variant for the hovered or actively dragged endpoint, and do not rely on color alone.
+- Rationale: A concrete shape, size, and contrast rule makes the discoverability objective testable while remaining independent of track colors and labels.
 - Alternatives considered:
-  - Increase hit radius to match affordance size (rejected: behavior change beyond scope).
+  - Color-only markers (rejected: weak against varied track colors and inaccessible for color-impaired users).
+  - Text labels or tooltips on every point (rejected: chart clutter and poorer scanability).
+
+### Decision 5: Keep hit testing and drag mechanics unchanged
+
+- Decision: Preserve existing jitter threshold checks, cursor transitions, drag action creation, undo/redo, course snapping, and planning-leg recalculation.
+- Rationale: The feature improves recognition without changing the established editing behavior.
+- Alternatives considered:
+  - Increase hit radius to match handle size (rejected: behavior change beyond scope).
   - Introduce alternative drag target semantics (rejected: would alter established workflows).
 
-### Decision 5: Define explicit visual state contract
+### Decision 6: Own rendering state per chart editor
 
-- Decision: Use distinct visual states for available, hovered, and active-drag targets while keeping non-draggable points unmarked.
-- Rationale: Clarifies what can be dragged and reinforces interaction feedback without extra clicks.
+- Decision: Keep marker collections, canvas references, hover state, and repaint listeners local to each chart editor. A shared drag-mode object must not contain mutable state that identifies one chart's markers as another chart's markers.
+- Rationale: `CoreDragAction.SwitchModeAction` currently installs the same mode instance across open chart editors, while `DragComponentMode` stores canvas and hover state on the mode. Per-editor ownership avoids stale markers, cross-editor leakage, and disposal bugs.
 - Alternatives considered:
-  - Cursor-only feedback (rejected: discoverability remains weak).
-  - Text labels/tooltips on every point (rejected: chart clutter and poorer scanability).
+  - Store one global marker collection in `PlotViewerPlugin` (rejected: chart projections and canvas lifecycles differ).
+  - Attach one shared paint listener to all canvases (rejected: listener cleanup and state ownership become ambiguous).
 
-### Decision 6: Validate with mixed automated and manual checks
+### Decision 7: Render from current geometry on repaint
 
-- Decision: Combine existing Tycho/RCPTT suites with manual planning-track scenarios using provided sample data.
-- Rationale: Existing automation covers command availability and data import; manual runs confirm in-chart affordance visibility and behavior under zoom/pan.
+- Decision: Convert current eligible endpoint locations to screen coordinates during repaint or an equivalent invalidated render pass; skip endpoints that cannot produce a screen coordinate for that frame.
+- Rationale: This keeps handles aligned after zoom, pan, recalculation, and drag operations without persisting screen coordinates.
+- Alternatives considered:
+  - Cache screen points until mouse movement (rejected: stale after viewport changes).
+  - Store screen coordinates in the planning model (rejected: screen coordinates are view-specific).
+
+### Decision 8: Validate with observable checks and a defined usability protocol
+
+- Decision: Combine existing Tycho/RCPTT suites with manual planning-track scenarios and a small before/after usability protocol using the provided sample data.
+- Rationale: Existing automation covers command availability and data import; visual marker presence, endpoint mapping, zoom/pan alignment, and discoverability require chart-level validation. The protocol makes the quantitative success criteria reproducible.
 - Alternatives considered:
   - Manual-only validation (rejected: insufficient regression confidence).
-  - New full end-to-end UI automation before implementation (rejected: useful but not required to begin feature work).
+  - Toolbar-only UI automation (rejected: it cannot validate chart affordances).
 
 ## Key Evidence from Code Inspection
 
 - Drag Component mode and hover target assignment are implemented in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`.
-- Planning-leg draggable endpoints are exposed in `org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java`.
+- Planning-leg draggable endpoints are exposed by the cursor-dependent path in `org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java`; a non-cursor-dependent enumeration path is required for all-marker rendering.
+- The nearest search traverses any visible `HasDraggableComponents` in `org.mwc.cmap.legacy/src/MWC/GUI/Shapes/FindNearest.java`; the new marker path must explicitly restrict itself to planning tracks.
 - Draggable component contracts are defined in `org.mwc.cmap.legacy/src/MWC/GUI/Shapes/HasDraggableComponents.java`.
+- Shared drag-mode installation occurs in `org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/actions/CoreDragAction.java`, and chart mode assignment occurs in `org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/editors/chart/SWTChart.java`.
 - Command/toolbar and keyboard wiring for Drag Component are in `org.mwc.debrief.core/plugin.xml` and `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/RadioHandler.java`.
 - Sample planning datasets for validation are under `org.mwc.cmap.combined.feature/root_installs/sample_data/`.
 
 ## Clarification Status
 
-All Technical Context clarifications are resolved; no `NEEDS CLARIFICATION` items remain.
+All Technical Context clarifications are resolved. The current model has no separate lock state; this feature uses existing visibility and endpoint eligibility rules instead of inventing one.

--- a/specs/002-drag-point-affordance/research.md
+++ b/specs/002-drag-point-affordance/research.md
@@ -1,0 +1,66 @@
+# Research: Draggable Track Point Affordance
+
+**Date**: 2026-09-04
+**Spec**: [spec.md](./spec.md)
+
+## Research Outcomes
+
+### Decision 1: Scope affordances to planning-track draggable endpoints only
+
+- Decision: Show affordances only for draggable points exposed by planning tracks when Drag Component mode is active.
+- Rationale: User need is to identify draggable planning-leg points; broader scope risks signaling drag support where none exists.
+- Alternatives considered:
+  - Show affordances for all track points in all drag modes (rejected: high false-positive risk).
+  - Show affordances only after hover (rejected: does not solve pre-hover discoverability).
+
+### Decision 2: Reuse existing hotspot source of truth
+
+- Decision: Use existing draggable hotspot generation from `Debrief.Wrappers.CompositeTrackWrapper.findNearestHotSpotIn(...)` as the source of draggable endpoints.
+- Rationale: This method already defines which planning-leg endpoints are draggable and how drag updates propagate to segment course/recalculation.
+- Alternatives considered:
+  - Derive draggable points from all visible fixes (rejected: not equivalent to true drag targets).
+  - Maintain a parallel draggable index (rejected: duplicate logic and drift risk).
+
+### Decision 3: Render affordances as mode-scoped overlay, not persisted model data
+
+- Decision: Render draggable-point affordances in Drag Component mode via chart repaint/overlay behavior rather than adding persistent entities to planning-track data.
+- Rationale: Affordance is interaction state, not domain state; this avoids file format and model persistence impact.
+- Alternatives considered:
+  - Add new flags/attributes to planning segments (rejected: unnecessary persistence coupling).
+  - Always paint affordances from track rendering code (rejected: cannot respect active tool state cleanly).
+
+### Decision 4: Keep hit testing and drag mechanics unchanged
+
+- Decision: Preserve existing jitter threshold checks, cursor transitions, drag action creation, undo/redo, and planning-leg recalc behavior.
+- Rationale: Requirement FR-008 requires no regression in existing drag behavior.
+- Alternatives considered:
+  - Increase hit radius to match affordance size (rejected: behavior change beyond scope).
+  - Introduce alternative drag target semantics (rejected: would alter established workflows).
+
+### Decision 5: Define explicit visual state contract
+
+- Decision: Use distinct visual states for available, hovered, and active-drag targets while keeping non-draggable points unmarked.
+- Rationale: Clarifies what can be dragged and reinforces interaction feedback without extra clicks.
+- Alternatives considered:
+  - Cursor-only feedback (rejected: discoverability remains weak).
+  - Text labels/tooltips on every point (rejected: chart clutter and poorer scanability).
+
+### Decision 6: Validate with mixed automated and manual checks
+
+- Decision: Combine existing Tycho/RCPTT suites with manual planning-track scenarios using provided sample data.
+- Rationale: Existing automation covers command availability and data import; manual runs confirm in-chart affordance visibility and behavior under zoom/pan.
+- Alternatives considered:
+  - Manual-only validation (rejected: insufficient regression confidence).
+  - New full end-to-end UI automation before implementation (rejected: useful but not required to begin feature work).
+
+## Key Evidence from Code Inspection
+
+- Drag Component mode and hover target assignment are implemented in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`.
+- Planning-leg draggable endpoints are exposed in `org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java`.
+- Draggable component contracts are defined in `org.mwc.cmap.legacy/src/MWC/GUI/Shapes/HasDraggableComponents.java`.
+- Command/toolbar and keyboard wiring for Drag Component are in `org.mwc.debrief.core/plugin.xml` and `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/RadioHandler.java`.
+- Sample planning datasets for validation are under `org.mwc.cmap.combined.feature/root_installs/sample_data/`.
+
+## Clarification Status
+
+All Technical Context clarifications are resolved; no `NEEDS CLARIFICATION` items remain.

--- a/specs/002-drag-point-affordance/spec.md
+++ b/specs/002-drag-point-affordance/spec.md
@@ -7,77 +7,79 @@
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - Recognize Draggable Points Quickly (Priority: P1)
+### User Story 1 - Recognize Draggable Leg Ends Quickly (Priority: P1)
 
-As an analyst editing a planning track, I can immediately recognize which track points are draggable when using the Drag Component tool, so I can adjust legs without trial and error.
+As an analyst editing a planning track, I can immediately recognize which leg ends are draggable when using the Drag Component tool, so I can adjust leg courses without trial and error.
 
 **Why this priority**: This is the core usability problem and directly affects whether users can perform leg-editing efficiently.
 
-**Independent Test**: Can be fully tested by loading a planning track, activating Drag Component, and confirming users can identify draggable points and move a leg without guesswork.
+**Independent Test**: Can be fully tested by loading a planning track, activating Drag Component, and confirming users can identify an eligible leg-end handle and move a leg without guesswork.
 
 **Acceptance Scenarios**:
 
-1. **Given** a planning track is loaded and editable, **When** the user activates Drag Component, **Then** every draggable track point is shown with a distinct visual cue.
-2. **Given** Drag Component is active, **When** the user attempts to edit a leg, **Then** they can identify the correct draggable point before starting the drag action.
+1. **Given** a visible planning track is loaded, **When** the user activates Drag Component, **Then** every currently draggable visible leg end is shown with a distinct endpoint handle.
+2. **Given** Drag Component is active, **When** the user attempts to edit a leg, **Then** the user can identify the leg end handle before starting the drag action and the existing drag interaction remains unchanged.
 
 ---
 
 ### User Story 2 - Avoid Confusion With Non-Draggable Elements (Priority: P2)
 
-As an analyst, I can distinguish draggable planning-track points from non-draggable points or other visual elements, so I do not waste time trying to drag unsupported targets.
+As an analyst, I can distinguish draggable planning-track leg ends from ordinary track points and other visual elements, so I do not waste time trying to drag unsupported targets.
 
 **Why this priority**: Preventing misclicks and false drag attempts reduces user frustration and avoids accidental workflow interruptions.
 
-**Independent Test**: Can be tested by presenting a mix of draggable and non-draggable points and verifying users only attempt drag actions on valid points.
+**Independent Test**: Can be tested by presenting planning and ordinary tracks together and verifying handles appear only on eligible planning-segment ends.
 
 **Acceptance Scenarios**:
 
-1. **Given** mixed editable and non-editable elements are visible, **When** Drag Component is active, **Then** only draggable planning-track points display the draggable affordance.
-2. **Given** a point is not draggable, **When** the user views it in edit mode, **Then** it does not appear as a draggable target.
+1. **Given** planning and ordinary tracks are visible together, **When** Drag Component is active, **Then** only eligible planning-track leg ends display the endpoint handle.
+2. **Given** a planning segment or endpoint is hidden or has no valid endpoint, **When** the user views it in Drag Component mode, **Then** it does not display an endpoint handle.
 
 ---
 
 ### User Story 3 - Preserve Visibility Across Normal Working Conditions (Priority: P3)
 
-As an analyst, I can still recognize draggable points while zooming and panning around planning tracks, so the affordance remains useful throughout normal editing workflows.
+As an analyst, I can still recognize draggable leg ends while zooming and panning around planning tracks, so the affordance remains useful throughout normal editing workflows.
 
 **Why this priority**: The feature must remain practical in real-world map usage, not only at one zoom level or static view.
 
-**Independent Test**: Can be tested by changing zoom levels and map view while Drag Component is active and confirming draggable points remain identifiable.
+**Independent Test**: Can be tested by changing zoom levels and map view while Drag Component is active and confirming endpoint handles remain aligned and identifiable.
 
 **Acceptance Scenarios**:
 
-1. **Given** Drag Component is active, **When** the user zooms in or out within supported editing views, **Then** draggable points remain visibly distinguishable from surrounding content.
+1. **Given** Drag Component is active, **When** the user zooms in or out within supported editing views, **Then** eligible leg-end handles remain aligned and visibly distinguishable from surrounding content.
 
 ---
 
 ### Edge Cases
 
 - Planning tracks with very closely spaced points must still allow users to identify which points can be dragged.
-- If a planning track or segment is locked/non-editable, drag affordances must not imply that dragging is available.
+- The current model has no separate lock state. Eligibility must follow the same visibility and endpoint rules used by the existing Drag Component hit test; introducing a new lock model is out of scope.
+- Closing segments are planning segments and must follow the same endpoint rule as other planning segments.
+- If two eligible endpoints project to the same or nearly the same screen location, the affordance must not change which candidate the existing hit test selects.
 - If the user switches tools rapidly (for example from Drag Component to another tool), draggable affordances must update to match the currently active tool state.
-- When no planning track is loaded, no draggable-point affordance should be shown.
+- When no planning track is loaded, no endpoint handle should be shown.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: The system MUST display a clear visual affordance on planning-track points that are draggable when Drag Component is active.
-- **FR-002**: The system MUST apply the affordance only to points that can currently be dragged.
-- **FR-003**: Users MUST be able to distinguish draggable planning-track points from non-draggable points without performing a trial drag.
+- **FR-001**: The system MUST display an endpoint handle centered on each eligible planning-segment end when Drag Component is active.
+- **FR-002**: The endpoint handle MUST be a high-contrast outlined marker with a contrasting center, have a minimum visible size of 8 screen pixels in both dimensions, and MUST NOT rely on color alone to communicate drag availability.
+- **FR-003**: The system MUST use a visually stronger variant of the endpoint handle while the pointer is over the corresponding draggable endpoint and while that endpoint is being dragged.
 - **FR-004**: The system MUST remove or suppress draggable-point affordances when Drag Component is not active.
-- **FR-005**: The system MUST update draggable-point affordances immediately when editability changes (for example due to lock/unlock state).
-- **FR-006**: The system MUST keep draggable-point affordances visible enough to recognize during typical zoom and pan interactions used for planning-track editing.
-- **FR-007**: The system MUST avoid signaling drag availability for tracks or points that cannot be modified.
-- **FR-008**: The system MUST preserve existing drag behavior for planning-track leg editing while adding the new affordance.
-- **FR-009**: The system MUST provide consistent draggable affordance behavior each time a planning track is loaded in an editable state.
+- **FR-005**: The system MUST derive endpoint-handle eligibility from visible planning segments with a valid last fix, using the same eligibility rules as the existing planning-track Drag Component hit test.
+- **FR-006**: The system MUST refresh endpoint handles on the next visible repaint after planning-track visibility, endpoint geometry, mode, zoom, or pan changes.
+- **FR-007**: The system MUST avoid signaling drag availability for ordinary tracks, non-planning plot elements, hidden planning segments, or hidden/invalid endpoints.
+- **FR-008**: The system MUST preserve existing Drag Component behavior, including hit tolerance, course snapping, planning-leg recalculation, undo, and redo.
+- **FR-009**: The system MUST keep affordance rendering state local to each chart editor; one editor's markers, hover state, or disposal MUST NOT affect another editor.
 
 ### Key Entities *(include if feature involves data)*
 
 - **Planning Track**: A user-created track used for planning, composed of legs and points that may be editable.
-- **Track Point**: A position marker within a planning track; may be draggable or non-draggable depending on current tool and editability state.
+- **Track Point**: A position marker within a planning track. For this feature, only the last valid fix of a visible planning segment is an affordance candidate; screen visibility is determined by the current chart projection.
 - **Drag Component Tool State**: The active editing mode that determines whether dragging interactions and their visual affordances are shown.
-- **Editability State**: The condition that determines whether a planning track or point can be modified at a given moment.
+- **Endpoint Eligibility**: The existing runtime condition that a planning segment is visible and has a valid last fix that the Drag Component hit-test path can modify. No separate persisted lock state or new endpoint-visibility rule is introduced by this feature.
 
 ### Assumptions
 
@@ -88,15 +90,15 @@ As an analyst, I can still recognize draggable points while zooming and panning 
 
 ### Dependencies
 
-- Accurate identification of planning-track points that are currently draggable.
-- Reliable detection of active tool mode and editability changes.
+- Accurate identification of planning-segment endpoints that are currently draggable.
+- Reliable detection of active tool mode, visibility, geometry, zoom, and pan changes.
 - Existing planning-track loading and leg-drag workflows remaining available.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: In usability validation, at least 90% of users correctly identify a draggable planning-track point within 5 seconds of activating Drag Component.
-- **SC-002**: In representative editing tasks, median time to begin a correct leg drag is reduced by at least 30% compared with the current behavior.
-- **SC-003**: Misattempts to drag non-draggable points decrease by at least 50% during observed planning-track editing sessions.
-- **SC-004**: At least 85% of users rate draggable-point discoverability as clear or very clear after completing a standard planning-track edit task.
+- **SC-001**: In the representative planning-track sample, 100% of eligible visible leg ends have exactly one visible endpoint handle when Drag Component is active, and no ineligible plot elements have one.
+- **SC-002**: In a usability evaluation of at least 5 analysts completing 10 representative leg-edit tasks each, at least 90% identify a correct endpoint handle within 5 seconds of activating Drag Component.
+- **SC-003**: Against the current build baseline using the same task script, the median time from Drag Component activation to the first correct leg drag decreases by at least 30%.
+- **SC-004**: In the same evaluation, at least 85% of participants rate endpoint discoverability as clear or very clear, and observed attempts to drag unsupported targets decrease by at least 50% against baseline.

--- a/specs/002-drag-point-affordance/spec.md
+++ b/specs/002-drag-point-affordance/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Draggable Track Point Affordance
+
+**Feature Branch**: `002-drag-point-affordance`  
+**Created**: 2026-09-04  
+**Status**: Draft  
+**Input**: User description: "we allow users to create planning tracks. Once loaded, they can use the \"Drag Component\" tool to drag the legs. We should offer an extra UI affordance on the draggable track points - to make it easier for the user to recognise which points can be dragged."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Recognize Draggable Points Quickly (Priority: P1)
+
+As an analyst editing a planning track, I can immediately recognize which track points are draggable when using the Drag Component tool, so I can adjust legs without trial and error.
+
+**Why this priority**: This is the core usability problem and directly affects whether users can perform leg-editing efficiently.
+
+**Independent Test**: Can be fully tested by loading a planning track, activating Drag Component, and confirming users can identify draggable points and move a leg without guesswork.
+
+**Acceptance Scenarios**:
+
+1. **Given** a planning track is loaded and editable, **When** the user activates Drag Component, **Then** every draggable track point is shown with a distinct visual cue.
+2. **Given** Drag Component is active, **When** the user attempts to edit a leg, **Then** they can identify the correct draggable point before starting the drag action.
+
+---
+
+### User Story 2 - Avoid Confusion With Non-Draggable Elements (Priority: P2)
+
+As an analyst, I can distinguish draggable planning-track points from non-draggable points or other visual elements, so I do not waste time trying to drag unsupported targets.
+
+**Why this priority**: Preventing misclicks and false drag attempts reduces user frustration and avoids accidental workflow interruptions.
+
+**Independent Test**: Can be tested by presenting a mix of draggable and non-draggable points and verifying users only attempt drag actions on valid points.
+
+**Acceptance Scenarios**:
+
+1. **Given** mixed editable and non-editable elements are visible, **When** Drag Component is active, **Then** only draggable planning-track points display the draggable affordance.
+2. **Given** a point is not draggable, **When** the user views it in edit mode, **Then** it does not appear as a draggable target.
+
+---
+
+### User Story 3 - Preserve Visibility Across Normal Working Conditions (Priority: P3)
+
+As an analyst, I can still recognize draggable points while zooming and panning around planning tracks, so the affordance remains useful throughout normal editing workflows.
+
+**Why this priority**: The feature must remain practical in real-world map usage, not only at one zoom level or static view.
+
+**Independent Test**: Can be tested by changing zoom levels and map view while Drag Component is active and confirming draggable points remain identifiable.
+
+**Acceptance Scenarios**:
+
+1. **Given** Drag Component is active, **When** the user zooms in or out within supported editing views, **Then** draggable points remain visibly distinguishable from surrounding content.
+
+---
+
+### Edge Cases
+
+- Planning tracks with very closely spaced points must still allow users to identify which points can be dragged.
+- If a planning track or segment is locked/non-editable, drag affordances must not imply that dragging is available.
+- If the user switches tools rapidly (for example from Drag Component to another tool), draggable affordances must update to match the currently active tool state.
+- When no planning track is loaded, no draggable-point affordance should be shown.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST display a clear visual affordance on planning-track points that are draggable when Drag Component is active.
+- **FR-002**: The system MUST apply the affordance only to points that can currently be dragged.
+- **FR-003**: Users MUST be able to distinguish draggable planning-track points from non-draggable points without performing a trial drag.
+- **FR-004**: The system MUST remove or suppress draggable-point affordances when Drag Component is not active.
+- **FR-005**: The system MUST update draggable-point affordances immediately when editability changes (for example due to lock/unlock state).
+- **FR-006**: The system MUST keep draggable-point affordances visible enough to recognize during typical zoom and pan interactions used for planning-track editing.
+- **FR-007**: The system MUST avoid signaling drag availability for tracks or points that cannot be modified.
+- **FR-008**: The system MUST preserve existing drag behavior for planning-track leg editing while adding the new affordance.
+- **FR-009**: The system MUST provide consistent draggable affordance behavior each time a planning track is loaded in an editable state.
+
+### Key Entities *(include if feature involves data)*
+
+- **Planning Track**: A user-created track used for planning, composed of legs and points that may be editable.
+- **Track Point**: A position marker within a planning track; may be draggable or non-draggable depending on current tool and editability state.
+- **Drag Component Tool State**: The active editing mode that determines whether dragging interactions and their visual affordances are shown.
+- **Editability State**: The condition that determines whether a planning track or point can be modified at a given moment.
+
+### Assumptions
+
+- The feature applies to planning tracks only, not all track types.
+- The Drag Component tool already exists and remains the primary interaction for moving planning-track legs.
+- Existing visual styling standards for the application remain in place, and this feature adds to them rather than redefining them.
+- Affordance visibility expectations are based on standard operator display settings used for routine Debrief analysis.
+
+### Dependencies
+
+- Accurate identification of planning-track points that are currently draggable.
+- Reliable detection of active tool mode and editability changes.
+- Existing planning-track loading and leg-drag workflows remaining available.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In usability validation, at least 90% of users correctly identify a draggable planning-track point within 5 seconds of activating Drag Component.
+- **SC-002**: In representative editing tasks, median time to begin a correct leg drag is reduced by at least 30% compared with the current behavior.
+- **SC-003**: Misattempts to drag non-draggable points decrease by at least 50% during observed planning-track editing sessions.
+- **SC-004**: At least 85% of users rate draggable-point discoverability as clear or very clear after completing a standard planning-track edit task.

--- a/specs/002-drag-point-affordance/tasks.md
+++ b/specs/002-drag-point-affordance/tasks.md
@@ -23,8 +23,8 @@ description: "Task list for implementing draggable planning-track point affordan
 **Purpose**: Prepare feature-local implementation and validation scaffolding.
 
 - [ ] T001 Capture implementation checkpoints and acceptance traceability notes in `specs/002-drag-point-affordance/plan.md`
-- [ ] T002 Confirm validation scenarios and expected outcomes are current in `specs/002-drag-point-affordance/quickstart.md`
-- [ ] T003 [P] Create RCPTT placeholder scenario file `org.mwc.debrief.ui_test/test-cases/toolbar/drag_component_affordance_visibility.test` aligned to `specs/002-drag-point-affordance/quickstart.md`
+- [ ] T002 Confirm validation scenarios, endpoint rules, and usability measurements in `specs/002-drag-point-affordance/quickstart.md`
+- [ ] T003 [P] Add an RCPTT chart-level scenario for Drag Component mode transitions in `org.mwc.debrief.ui_test/test-cases/toolbar/drag_component_affordance_visibility.test`
 
 ---
 
@@ -34,29 +34,29 @@ description: "Task list for implementing draggable planning-track point affordan
 
 **CRITICAL**: Complete this phase before starting any user story tasks.
 
-- [ ] T004 Add runtime affordance state fields and lifecycle reset hooks in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T005 [P] Add planning-endpoint collection helper(s) for affordance rendering in `org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java`
-- [ ] T006 [P] Add Drag Component helper methods that derive eligible affordance candidates from layers and mode state in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T007 Wire repaint invalidation for affordance updates on mode entry/exit and pointer movement in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T004 Define per-chart affordance state and disposal ownership in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java` and `org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/actions/CoreDragAction.java`
+- [ ] T005 [P] Add a non-cursor-dependent planning-endpoint enumeration helper in `org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java` for visible segments with valid last fixes
+- [ ] T006 [P] Refactor or share endpoint eligibility between enumeration and nearest-hit logic in `org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java`
+- [ ] T007 Wire per-chart repaint invalidation and cleanup for mode, visibility, geometry, zoom, pan, and canvas disposal in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`, `org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/editors/chart/SWTChart.java`, and `org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/actions/CoreDragAction.java`
 
 **Checkpoint**: Foundation complete; user stories can now be implemented.
 
 ---
 
-## Phase 3: User Story 1 - Recognize Draggable Points Quickly (Priority: P1) MVP
+## Phase 3: User Story 1 - Recognize Draggable Leg Ends Quickly (Priority: P1) MVP
 
-**Goal**: Users can immediately identify draggable planning-track points when Drag Component mode is active.
+**Goal**: Users can immediately identify eligible planning-segment ends when Drag Component mode is active.
 
-**Independent Test**: Load a planning track, activate Drag Component, and verify draggable endpoints are visibly marked before any drag starts.
+**Independent Test**: Load a planning track, activate Drag Component, and verify every eligible visible segment end has a high-contrast endpoint handle before any drag starts.
 
 ### Implementation for User Story 1
 
-- [ ] T008 [US1] Render default draggable-point affordance markers for eligible planning endpoints in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T009 [US1] Add hover-state marker emphasis synchronized with `_hoverComponent` updates in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T010 [US1] Preserve visible affordance feedback during active drag preview/commit flow in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T011 [US1] Guard marker rendering for off-screen/invalid coordinate conversions in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T008 [US1] Render an outlined endpoint handle with contrasting center and minimum 8-pixel screen size for each eligible endpoint in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T009 [US1] Add stronger hovered and actively dragged handle states synchronized with existing `_hoverComponent` and drag state in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T010 [US1] Preserve endpoint handle visibility and existing drag semantics during preview, commit, undo, and redo in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T011 [US1] Guard marker rendering for off-screen/invalid coordinate conversions and avoid color-only communication in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
 - [ ] T012 [P] [US1] Update user-facing Drag Component guidance to describe draggable-point affordances in `org.mwc.debrief.help/docbook/ng_help.xml`
-- [ ] T013 [US1] Execute US1 scenario validation and record pass/fail notes in `specs/002-drag-point-affordance/quickstart.md`
+- [ ] T013 [US1] Execute US1 sample-data validation, count eligible versus rendered endpoints, and record evidence in `specs/002-drag-point-affordance/quickstart.md`
 
 **Checkpoint**: User Story 1 is complete and independently verifiable.
 
@@ -64,17 +64,17 @@ description: "Task list for implementing draggable planning-track point affordan
 
 ## Phase 4: User Story 2 - Avoid Confusion With Non-Draggable Elements (Priority: P2)
 
-**Goal**: Users can distinguish draggable planning points from non-draggable points and unrelated chart elements.
+**Goal**: Users can distinguish eligible planning-segment ends from ordinary track points and unrelated chart elements.
 
-**Independent Test**: With mixed visible content, verify only truly draggable planning points show affordances and non-draggable targets never appear draggable.
+**Independent Test**: With planning and ordinary tracks visible together, verify only eligible planning-segment ends show handles and hidden/invalid endpoints do not.
 
 ### Implementation for User Story 2
 
-- [ ] T014 [US2] Restrict affordance candidate enumeration to planning-track draggable endpoints only in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T015 [US2] Exclude hidden or non-editable planning segments from affordance output in `org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java` and `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T016 [US2] Ensure non-planning `TrackWrapper` content and other plottables do not receive affordance markers in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T017 [US2] Align hit-cursor transitions with affordance eligibility so false targets never show point-hit cursor in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T018 [US2] Execute US2 scenario validation and record false-positive checks in `specs/002-drag-point-affordance/quickstart.md`
+- [ ] T014 [US2] Restrict marker candidate enumeration to `CompositeTrackWrapper` planning endpoints in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T015 [US2] Exclude hidden segments, empty segments, and invalid screen locations without adding a new endpoint-visibility rule in `org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java` and `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T016 [US2] Ensure ordinary `TrackWrapper` content and other plottables do not receive endpoint handles in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T017 [US2] Preserve existing nearest-hit and cursor behavior for overlapping candidates without introducing a new hit target in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T018 [US2] Execute US2 visibility, closing-segment, overlap, and false-positive validation and record evidence in `specs/002-drag-point-affordance/quickstart.md`
 
 **Checkpoint**: User Story 2 is complete and independently verifiable.
 
@@ -88,11 +88,11 @@ description: "Task list for implementing draggable planning-track point affordan
 
 ### Implementation for User Story 3
 
-- [ ] T019 [US3] Recompute affordance screen geometry on each repaint so markers stay aligned through zoom/pan in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T020 [US3] Clear affordance state on mode switch by extending drag-mode lifecycle cleanup in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T021 [US3] Harden drag affordance redraw paths for rapid tool switching and null/disposing editor states in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T022 [US3] Verify cross-editor consistency of Drag Component affordance behavior with shared mode switching flow in `org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/actions/CoreDragAction.java` and `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
-- [ ] T023 [US3] Execute US3 scenario validation and record zoom/pan and mode-transition outcomes in `specs/002-drag-point-affordance/quickstart.md`
+- [ ] T019 [US3] Recompute handle screen geometry from current projection on repaint so markers stay aligned through zoom/pan in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T020 [US3] Clear per-chart handle state and listeners on mode switch by extending drag-mode lifecycle cleanup in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java` and `org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/actions/CoreDragAction.java`
+- [ ] T021 [US3] Harden redraw and disposal paths for rapid tool switching, null editors, and disposed canvases in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java` and `org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/editors/chart/SWTChart.java`
+- [ ] T022 [US3] Verify that shared mode switching creates or maintains independent chart-local handle state across open editors in `org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/actions/CoreDragAction.java`
+- [ ] T023 [US3] Execute US3 zoom, pan, rapid-switch, disposal, and multiple-editor validation and record evidence in `specs/002-drag-point-affordance/quickstart.md`
 
 **Checkpoint**: User Story 3 is complete and independently verifiable.
 
@@ -102,9 +102,9 @@ description: "Task list for implementing draggable planning-track point affordan
 
 **Purpose**: Final hardening, regression coverage, and release-readiness evidence.
 
-- [ ] T024 [P] Add RCPTT assertions for affordance visibility lifecycle in `org.mwc.debrief.ui_test/test-cases/toolbar/drag_component_affordance_visibility.test`
-- [ ] T025 [P] Add or extend planning-track drag regression coverage in `org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/TrackWrapper_Test.java`
-- [ ] T026 Run full quickstart validation pass and update final evidence links in `specs/002-drag-point-affordance/quickstart.md` and `specs/002-drag-point-affordance/contracts/drag-component-affordance.md`
+- [ ] T024 [P] Add RCPTT assertions for Drag Component mode transitions and chart lifecycle in `org.mwc.debrief.ui_test/test-cases/toolbar/drag_component_affordance_visibility.test`
+- [ ] T025 [P] Add or extend planning-endpoint eligibility regression coverage in `org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/TrackWrapper_Test.java`
+- [ ] T026 Run the full quickstart validation protocol, including usability measurements, and update evidence links in `specs/002-drag-point-affordance/quickstart.md` and `specs/002-drag-point-affordance/contracts/drag-component-affordance.md`
 
 ---
 
@@ -149,14 +149,14 @@ Recommended delivery order: US1 -> US2 -> US3
 ## Parallel Example: User Story 1
 
 ```bash
-Task: "T008 [US1] Render default draggable-point affordance markers in org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java"
+Task: "T008 [US1] Render concrete endpoint handles in org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java"
 Task: "T012 [US1] Update Drag Component guidance in org.mwc.debrief.help/docbook/ng_help.xml"
 ```
 
 ## Parallel Example: User Story 2
 
 ```bash
-Task: "T015 [US2] Exclude hidden or non-editable planning segments in org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java"
+Task: "T015 [US2] Exclude hidden or invalid planning endpoints in org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java"
 Task: "T016 [US2] Exclude non-planning plottables in org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java"
 ```
 

--- a/specs/002-drag-point-affordance/tasks.md
+++ b/specs/002-drag-point-affordance/tasks.md
@@ -1,0 +1,199 @@
+---
+
+description: "Task list for implementing draggable planning-track point affordances"
+---
+
+# Tasks: Draggable Track Point Affordance
+
+**Input**: Design documents from `/specs/002-drag-point-affordance/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: No TDD-first requirement was explicitly requested in the specification, so this plan uses implementation tasks plus scenario validation tasks.
+
+**Organization**: Tasks are grouped by user story so each story remains independently implementable and independently verifiable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Task can run in parallel (different files, no dependency on unfinished tasks)
+- **[Story]**: User story label (`[US1]`, `[US2]`, `[US3]`) used only in story phases
+- Every task includes at least one concrete repository file path
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare feature-local implementation and validation scaffolding.
+
+- [ ] T001 Capture implementation checkpoints and acceptance traceability notes in `specs/002-drag-point-affordance/plan.md`
+- [ ] T002 Confirm validation scenarios and expected outcomes are current in `specs/002-drag-point-affordance/quickstart.md`
+- [ ] T003 [P] Create RCPTT placeholder scenario file `org.mwc.debrief.ui_test/test-cases/toolbar/drag_component_affordance_visibility.test` aligned to `specs/002-drag-point-affordance/quickstart.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build shared drag-affordance infrastructure required by all stories.
+
+**CRITICAL**: Complete this phase before starting any user story tasks.
+
+- [ ] T004 Add runtime affordance state fields and lifecycle reset hooks in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T005 [P] Add planning-endpoint collection helper(s) for affordance rendering in `org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java`
+- [ ] T006 [P] Add Drag Component helper methods that derive eligible affordance candidates from layers and mode state in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T007 Wire repaint invalidation for affordance updates on mode entry/exit and pointer movement in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+
+**Checkpoint**: Foundation complete; user stories can now be implemented.
+
+---
+
+## Phase 3: User Story 1 - Recognize Draggable Points Quickly (Priority: P1) MVP
+
+**Goal**: Users can immediately identify draggable planning-track points when Drag Component mode is active.
+
+**Independent Test**: Load a planning track, activate Drag Component, and verify draggable endpoints are visibly marked before any drag starts.
+
+### Implementation for User Story 1
+
+- [ ] T008 [US1] Render default draggable-point affordance markers for eligible planning endpoints in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T009 [US1] Add hover-state marker emphasis synchronized with `_hoverComponent` updates in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T010 [US1] Preserve visible affordance feedback during active drag preview/commit flow in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T011 [US1] Guard marker rendering for off-screen/invalid coordinate conversions in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T012 [P] [US1] Update user-facing Drag Component guidance to describe draggable-point affordances in `org.mwc.debrief.help/docbook/ng_help.xml`
+- [ ] T013 [US1] Execute US1 scenario validation and record pass/fail notes in `specs/002-drag-point-affordance/quickstart.md`
+
+**Checkpoint**: User Story 1 is complete and independently verifiable.
+
+---
+
+## Phase 4: User Story 2 - Avoid Confusion With Non-Draggable Elements (Priority: P2)
+
+**Goal**: Users can distinguish draggable planning points from non-draggable points and unrelated chart elements.
+
+**Independent Test**: With mixed visible content, verify only truly draggable planning points show affordances and non-draggable targets never appear draggable.
+
+### Implementation for User Story 2
+
+- [ ] T014 [US2] Restrict affordance candidate enumeration to planning-track draggable endpoints only in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T015 [US2] Exclude hidden or non-editable planning segments from affordance output in `org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java` and `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T016 [US2] Ensure non-planning `TrackWrapper` content and other plottables do not receive affordance markers in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T017 [US2] Align hit-cursor transitions with affordance eligibility so false targets never show point-hit cursor in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T018 [US2] Execute US2 scenario validation and record false-positive checks in `specs/002-drag-point-affordance/quickstart.md`
+
+**Checkpoint**: User Story 2 is complete and independently verifiable.
+
+---
+
+## Phase 5: User Story 3 - Preserve Visibility Across Normal Working Conditions (Priority: P3)
+
+**Goal**: Affordances remain useful during zoom, pan, and rapid tool switching.
+
+**Independent Test**: While Drag Component is active, zoom/pan and switch tools repeatedly; verify affordances stay aligned when active and disappear when inactive.
+
+### Implementation for User Story 3
+
+- [ ] T019 [US3] Recompute affordance screen geometry on each repaint so markers stay aligned through zoom/pan in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T020 [US3] Clear affordance state on mode switch by extending drag-mode lifecycle cleanup in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T021 [US3] Harden drag affordance redraw paths for rapid tool switching and null/disposing editor states in `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T022 [US3] Verify cross-editor consistency of Drag Component affordance behavior with shared mode switching flow in `org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/actions/CoreDragAction.java` and `org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java`
+- [ ] T023 [US3] Execute US3 scenario validation and record zoom/pan and mode-transition outcomes in `specs/002-drag-point-affordance/quickstart.md`
+
+**Checkpoint**: User Story 3 is complete and independently verifiable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final hardening, regression coverage, and release-readiness evidence.
+
+- [ ] T024 [P] Add RCPTT assertions for affordance visibility lifecycle in `org.mwc.debrief.ui_test/test-cases/toolbar/drag_component_affordance_visibility.test`
+- [ ] T025 [P] Add or extend planning-track drag regression coverage in `org.mwc.debrief.legacy/src/Debrief/Wrappers/Track/TrackWrapper_Test.java`
+- [ ] T026 Run full quickstart validation pass and update final evidence links in `specs/002-drag-point-affordance/quickstart.md` and `specs/002-drag-point-affordance/contracts/drag-component-affordance.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Phase 1 -> Phase 2 -> Phase 3/4/5 -> Phase 6
+- User stories may begin only after Phase 2 completes
+
+### User Story Dependency Graph
+
+```text
+Foundation (Phase 2)
+    |
+    +--> US1 (P1)
+    |
+    +--> US2 (P2)
+    |
+    +--> US3 (P3)
+
+Recommended delivery order: US1 -> US2 -> US3
+```
+
+### Task-Level Dependencies
+
+- T004-T007 must complete before T008-T023
+- T008-T011 should complete before T013
+- T014-T017 should complete before T018
+- T019-T022 should complete before T023
+- T024-T026 run after selected user stories are complete
+
+---
+
+## Parallel Opportunities
+
+- **Setup**: T003 can run in parallel with T001-T002
+- **Foundational**: T005 and T006 can run in parallel, then merge into T007
+- **US1**: T012 can run in parallel with T008-T011
+- **Polish**: T024 and T025 can run in parallel before T026
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "T008 [US1] Render default draggable-point affordance markers in org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java"
+Task: "T012 [US1] Update Drag Component guidance in org.mwc.debrief.help/docbook/ng_help.xml"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "T015 [US2] Exclude hidden or non-editable planning segments in org.mwc.debrief.legacy/src/Debrief/Wrappers/CompositeTrackWrapper.java"
+Task: "T016 [US2] Exclude non-planning plottables in org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "T020 [US3] Clear affordance state on mode switch in org.mwc.debrief.core/src/org/mwc/debrief/core/actions/DragComponent.java"
+Task: "T022 [US3] Verify cross-editor consistency in org.mwc.cmap.plotViewer/src/org/mwc/cmap/plotViewer/actions/CoreDragAction.java"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Complete Phase 1 and Phase 2
+2. Deliver Phase 3 (US1) and run T013 validation
+3. Demo/review affordance discoverability improvement before expanding scope
+
+### Incremental Delivery
+
+1. Deliver US1 (discoverability baseline)
+2. Deliver US2 (false-positive prevention)
+3. Deliver US3 (zoom/pan and mode-switch resilience)
+4. Complete polish tasks and final validation evidence
+
+### Team Parallelization Strategy
+
+1. One developer handles `CompositeTrackWrapper` endpoint exposure (T005/T015)
+2. One developer handles Drag Component overlay and lifecycle tasks (T004/T006/T007/T008-T011/T014/T016-T021)
+3. One developer handles docs and UI automation (T003/T012/T024/T026)
+
+---
+
+## Notes
+
+- [P] tasks are limited to work that can proceed without waiting on unfinished same-file edits.
+- Story labels map implementation work directly to `spec.md` user stories for traceability.
+- Validation tasks reference `quickstart.md` so each story can be demonstrated independently.


### PR DESCRIPTION
## Summary
- add complete specification package for draggable planning-track point affordance
- include plan, research, data model, UI contract, quickstart, and execution tasks
- keep change isolated to specs/002-drag-point-affordance/ for planning and implementation handoff

## Testing
- not run (documentation/spec artifacts only)